### PR TITLE
fix redirecting issue in the middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -9,7 +9,6 @@ export async function middleware(request: NextRequest) {
 
   const { pathname } = request.nextUrl;
 
-  // Handle explicit logout logic
   if (pathname === '/auth/login') {
     // If the user is already logged in, redirect them to the appropriate dashboard
     if (token && userType) {


### PR DESCRIPTION
whenever someone reloads the website from the main url or visits the site again after logging, the user still gets redirected to login page and not the dashboard. The above PR fixes this