### PR TITLE
SP3-195-[BUGFIX]-infinite-api-call-busines-talent-page

### DIFF
--- a/src/components/business/hireTalent.tsx/talentCard.tsx
+++ b/src/components/business/hireTalent.tsx/talentCard.tsx
@@ -89,7 +89,7 @@ const TalentCard: React.FC<TalentCardProps> = ({
 }) => {
   const [filteredTalents, setFilteredTalents] = useState<Talent[]>([]);
   const [talents, setTalents] = useState<Talent[]>([]);
-  const [skip, setSkip] = useState(0);
+  const skipRef = useRef(0);
   const [loading, setLoading] = useState(false);
   const [hasMore, setHasMore] = useState(true);
   const isRequestInProgress = useRef(false);
@@ -254,12 +254,7 @@ const TalentCard: React.FC<TalentCardProps> = ({
         });
       }
     }
-  }, [
-    user?.uid,
-    skillDomainFormProps,
-    skillDomainFormProps?.skillFilter,
-    skillDomainFormProps?.domainFilter,
-  ]);
+  }, [user?.uid, skillDomainFormProps]);
 
   useEffect(() => {
     fetchUserData();
@@ -272,8 +267,8 @@ const TalentCard: React.FC<TalentCardProps> = ({
   };
 
   const fetchTalentData = useCallback(
-    async (newSkip = skip, reset = false) => {
-      if (isRequestInProgress.current || loading || !hasMore) return;
+    async (newSkip = skipRef.current, reset = false) => {
+      if (isRequestInProgress.current) return;
 
       try {
         isRequestInProgress.current = true;
@@ -283,19 +278,19 @@ const TalentCard: React.FC<TalentCardProps> = ({
           `freelancer/dehixtalent?limit=${Dehix_Talent_Card_Pagination.BATCH}&skip=${newSkip}`,
         );
 
-        if (response.data.data.length < Dehix_Talent_Card_Pagination.BATCH) {
+        const fetchedData = response?.data?.data || [];
+
+        if (fetchedData.length < Dehix_Talent_Card_Pagination.BATCH) {
           setHasMore(false);
-          setTalents((prev) =>
-            reset ? response.data.data : [...prev, ...response.data.data],
-          );
-          return;
         }
 
         if (response?.data?.data) {
           setTalents((prev) =>
-            reset ? response.data.data : [...prev, ...response.data.data],
+            reset ? fetchedData : [...prev, ...fetchedData],
           );
-          setSkip(newSkip + Dehix_Talent_Card_Pagination.BATCH);
+          skipRef.current = reset
+            ? Dehix_Talent_Card_Pagination.BATCH
+            : skipRef.current + Dehix_Talent_Card_Pagination.BATCH;
         } else {
           throw new Error('Fail to fetch data');
         }
@@ -315,21 +310,21 @@ const TalentCard: React.FC<TalentCardProps> = ({
         isRequestInProgress.current = false;
       }
     },
-    [skip, loading, hasMore],
+    [],
   );
 
   // Function to reset state when filters change
   const resetAndFetchData = useCallback(() => {
     setTalents([]);
-    setSkip(0);
+    skipRef.current = 0;
     setHasMore(true);
     fetchTalentData(0, true); // Pass 0 as the skip value to start from the beginning
-  }, [skillFilter, domainFilter, fetchTalentData]);
+  }, [fetchTalentData]);
 
   // Reload cards when filter changes
   useEffect(() => {
     resetAndFetchData();
-  }, [skillFilter, domainFilter, resetAndFetchData]);
+  }, [resetAndFetchData]);
 
   // Apply the filters to the talents
   useEffect(() => {


### PR DESCRIPTION
Adding skip to the dependency array caused an infinite loop , leading to Infinite API calls. This happened because setSkip triggered a re-render (resetAndFetchData) , which then re-executed the useEffect and useCallback functions.

To prevent this, the skip state was removed and added ref to avoid Infinite API calls.

BEFORE
https://github.com/user-attachments/assets/521b3c3b-247e-4fc0-b2e0-638eec79d3d5

AFTER
https://github.com/user-attachments/assets/d69d5e44-486b-43b8-8b87-41599fdfd0d5

