### PR TITLE
SP3-206-update-login-otp-flow

### DIFF
--- a/src/components/shared/PhoneChangeModal.tsx
+++ b/src/components/shared/PhoneChangeModal.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import React, { useState } from 'react';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle,
+} from '../ui/dialog';
+import { Label } from '../ui/label';
+import { Input } from '../ui/input';
+import { Button } from '../ui/button';
+import { Loader2 } from 'lucide-react';
+import { toast } from '../ui/use-toast';
+
+interface PhoneChangeModalProps {
+    open: boolean;
+    setOpen: (value: boolean) => void;
+    onSubmit: any;
+    setPhone: any;
+}
+
+const PhoneChangeModal: React.FC<PhoneChangeModalProps> = ({ open, setOpen, onSubmit, setPhone }) => {
+    const [newPhone, setNewPhone] = useState('');
+    const [loading, setLoading] = useState(false);
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+
+        if (newPhone.length !== 10) {
+            toast({
+                variant: 'destructive',
+                title: 'Invalid Phone Number',
+                description: 'Please enter a valid 10-digit number.',
+            });
+            return;
+        }
+
+        try {
+            setLoading(true);
+            const formattedPhone = `+91${newPhone}`;
+            setPhone(formattedPhone);
+            await onSubmit(formattedPhone);
+            toast({
+                title: 'Sending OTP',
+                description: `Sending OTP to ${formattedPhone}. Please wait...`,
+            });
+            setOpen(false);
+        } catch (error) {
+            toast({
+                variant: 'destructive',
+                title: 'Failed to Send OTP',
+                description: 'Something went wrong. Please try again.',
+            });
+        } finally {
+            setLoading(false);
+        }
+    };
+
+
+    return (
+        <Dialog open={open} onOpenChange={setOpen}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Change Phone Number</DialogTitle>
+                    <DialogDescription>
+                        Enter a new phone number to receive the OTP.
+                    </DialogDescription>
+                </DialogHeader>
+
+                <form onSubmit={handleSubmit} className="space-y-4 mt-2">
+                    <div>
+                        <Label className="mb-1 block">New Phone Number</Label>
+                        <div className='mt-2'>
+                            <Input
+                                type="tel"
+                                value={newPhone}
+                                onChange={(e) => {
+                                    const value = e.target.value.replace(/\D/g, '');
+                                    if (value.length <= 10) setNewPhone(value);
+                                }}
+                                maxLength={10}
+                                placeholder="Enter 10-digit number"
+                                disabled={loading}
+                            />
+                        </div>
+                    </div>
+
+                    <div className="flex justify-end gap-2">
+                        <Button
+                            variant="secondary"
+                            type="button"
+                            onClick={() => setOpen(false)}
+                            disabled={loading}
+                        >
+                            Cancel
+                        </Button>
+                        <Button type="submit" disabled={loading}>
+                            {loading ? (
+                                <>
+                                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                    Sending...
+                                </>
+                            ) : (
+                                'Send OTP'
+                            )}
+                        </Button>
+                    </div>
+                </form>
+            </DialogContent>
+        </Dialog>
+    );
+};
+
+export default PhoneChangeModal;

--- a/src/components/shared/otpDialog.tsx
+++ b/src/components/shared/otpDialog.tsx
@@ -35,6 +35,7 @@ import { setUser } from '@/lib/userSlice';
 import { getUserData } from '@/lib/utils';
 import { axiosInstance } from '@/lib/axiosinstance';
 import { toast } from '@/hooks/use-toast';
+import PhoneChangeModal from './PhoneChangeModal';
 
 interface OtpLoginProps {
   phoneNumber: string;
@@ -57,6 +58,9 @@ function OtpLogin({ phoneNumber, isModalOpen, setIsModalOpen }: OtpLoginProps) {
     useState<ConfirmationResult | null>(null);
 
   const [isPending, startTransition] = useTransition();
+  const [otpSent, setOtpSent] = useState(false);
+  const [showModal, setShowModal] = useState(false);
+  const [phone, setPhone] = useState(phoneNumber || '');
 
   useEffect(() => {
     let timer: NodeJS.Timeout;
@@ -65,6 +69,7 @@ function OtpLogin({ phoneNumber, isModalOpen, setIsModalOpen }: OtpLoginProps) {
     }
     return () => clearTimeout(timer);
   }, [resendCountdown]);
+
   useEffect(() => {
     const recaptchaVerifier = new RecaptchaVerifier(
       auth,
@@ -95,10 +100,9 @@ function OtpLogin({ phoneNumber, isModalOpen, setIsModalOpen }: OtpLoginProps) {
           await confirmationResult?.confirm(otp);
 
         const { user, claims } = await getUserData(userCredential);
-
         // Update phone verification status in mongoDb and firebase
         await axiosInstance.put(`/${claims.type}`, {
-          phone: phoneNumber,
+          phone: phone,
           phoneVerify: true,
         });
 
@@ -124,31 +128,24 @@ function OtpLogin({ phoneNumber, isModalOpen, setIsModalOpen }: OtpLoginProps) {
   }, [otp, verifyOtp]);
 
   const requestOtp = useCallback(
-    async (e?: FormEvent<HTMLFormElement>) => {
-      e?.preventDefault();
-
-      setResendCountdown(60);
-
+    async () => {
       startTransition(async () => {
         setError('');
-
+        setResendCountdown(60);
         if (!recaptchaVerifier) {
           return setError('RecaptchaVerifier is not initialized.');
         }
-
         try {
           const confirmationResult = await signInWithPhoneNumber(
             auth,
-            phoneNumber,
+            phone,
             recaptchaVerifier,
           );
-
           setConfirmationResult(confirmationResult);
           setSuccess('OTP sent successfully.');
         } catch (err: any) {
-          console.log(err);
+          console.error(err);
           setResendCountdown(0);
-
           if (err.code === 'auth/invalid-phone-number') {
             setError('Invalid phone number. Please check the number.');
           } else if (err.code === 'auth/too-many-requests') {
@@ -159,8 +156,14 @@ function OtpLogin({ phoneNumber, isModalOpen, setIsModalOpen }: OtpLoginProps) {
         }
       });
     },
-    [recaptchaVerifier, phoneNumber],
+    [recaptchaVerifier, phone],
   );
+
+  const handlePhoneChange = (newPhone: string) => {
+    setPhone(newPhone);
+    requestOtp();
+    setShowModal(false);
+  };
 
   useEffect(() => {
     if (isModalOpen) {
@@ -195,11 +198,21 @@ function OtpLogin({ phoneNumber, isModalOpen, setIsModalOpen }: OtpLoginProps) {
       <Dialog open={isModalOpen} onOpenChange={setIsModalOpen}>
         <DialogContent>
           <DialogHeader>
+            <p className="text-sm text-center text-gray-500">
+              OTP sent to <strong>{phone.substring(0, 3)} {phone.substring(3)}</strong>
+            </p>
+            <button
+              className="text-blue-600 text-sm underline mt-1"
+              onClick={() => setShowModal(true)}
+            >
+              Not your number? Change it
+            </button>
             <DialogTitle>Enter OTP</DialogTitle>
             <DialogDescription>
               Please enter the OTP sent to your phone number.
             </DialogDescription>
           </DialogHeader>
+
           <div className="flex flex-col justify-center items-center">
             <InputOTP
               maxLength={6}
@@ -218,6 +231,7 @@ function OtpLogin({ phoneNumber, isModalOpen, setIsModalOpen }: OtpLoginProps) {
                 <InputOTPSlot index={5} />
               </InputOTPGroup>
             </InputOTP>
+
             <Button
               disabled={isPending || resendCountdown > 0}
               className="mt-5"
@@ -228,6 +242,7 @@ function OtpLogin({ phoneNumber, isModalOpen, setIsModalOpen }: OtpLoginProps) {
                   ? 'Sending OTP'
                   : 'Send OTP'}
             </Button>
+
             <div className="p-10 text-center">
               {error && <p className="text-red-500">{error}</p>}
               {success && <p className="text-green-500">{success}</p>}
@@ -236,6 +251,14 @@ function OtpLogin({ phoneNumber, isModalOpen, setIsModalOpen }: OtpLoginProps) {
           </div>
         </DialogContent>
       </Dialog>
+
+      <PhoneChangeModal
+        open={showModal}
+        setOpen={setShowModal}
+        onSubmit={handlePhoneChange}
+        setPhone={setPhone}
+      />
+
       <div id="recaptcha-container" />
     </>
   );

--- a/src/components/shared/otpDialog.tsx
+++ b/src/components/shared/otpDialog.tsx
@@ -60,7 +60,7 @@ function OtpLogin({ phoneNumber, isModalOpen, setIsModalOpen }: OtpLoginProps) {
   const [isPending, startTransition] = useTransition();
   const [otpSent, setOtpSent] = useState(false);
   const [showModal, setShowModal] = useState(false);
-  const [phone, setPhone] = useState(phoneNumber || '');
+  const [phone, setPhone] = useState(phoneNumber);
 
   useEffect(() => {
     let timer: NodeJS.Timeout;
@@ -199,7 +199,7 @@ function OtpLogin({ phoneNumber, isModalOpen, setIsModalOpen }: OtpLoginProps) {
         <DialogContent>
           <DialogHeader>
             <p className="text-sm text-center text-gray-500">
-              OTP sent to <strong>{phone.substring(0, 3)} {phone.substring(3)}</strong>
+              OTP sent to <strong>{(phone || phoneNumber).substring(0, 3)} {(phone || phoneNumber).substring(3)}</strong>
             </p>
             <button
               className="text-blue-600 text-sm underline mt-1"


### PR DESCRIPTION

If the user's phone number is not verified, the OTP modal will open as before.  I've just added an option to change the number — if the user updates it, an OTP will be sent to the new number and the phone number will be updated in Firebase

https://github.com/user-attachments/assets/0c13e767-51d6-47f7-b855-74d1a3f623fa

