### PR TITLE
WIP-SP3-300-aditya-redux-fixes

### DIFF
--- a/src/app/AuthContext.tsx
+++ b/src/app/AuthContext.tsx
@@ -23,6 +23,14 @@ const setLocalStorageItem = (key: string, value: string) =>
   localStorage.setItem(key, value);
 const removeLocalStorageItem = (key: string) => localStorage.removeItem(key);
 
+// Helper function to extract serializable user data
+const getSerializableUserData = (user: User, type?: string) => ({
+  uid: user.uid,
+  email: user.email,
+  displayName: user.displayName,
+  type: type,
+});
+
 export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const router = useRouter();
   const [user, setUserState] = useState<User | null>(null);
@@ -38,7 +46,8 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         const parsedUser = JSON.parse(storedUser);
         setUserState(parsedUser);
         initializeAxiosWithToken(storedToken);
-        dispatch(setUser(parsedUser));
+        // Only dispatch serializable user data
+        dispatch(setUser(getSerializableUserData(parsedUser, parsedUser.type)));
       } catch (error) {
         console.error('Failed to parse user:', error);
         removeLocalStorageItem('user');
@@ -57,7 +66,8 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
             setLocalStorageItem('token', accessToken);
             setUserState(userData);
             initializeAxiosWithToken(accessToken);
-            dispatch(setUser(userData));
+            // Only dispatch serializable user data
+            dispatch(setUser(getSerializableUserData(firebaseUser, claims.claims.type as string)));
           }
         } catch (error) {
           console.error('Token Refresh Error:', error);


### PR DESCRIPTION
###  Fix: Prevent Non-Serializable Firebase Fields from Being Stored in Redux 

####  Issue 

Redux Toolkit warned about non-serializable values in the Redux state:

```
A non-serializable value was detected in an action, in the path: `payload.proactiveRefresh`
```

This happened because the full `firebaseUser` object (which includes internal fields like `proactiveRefresh`, functions, etc.) was being dispatched directly to Redux.

####  Solution 

* Extracted only serializable properties (`uid`, `email`, `displayName`, `type`) from the Firebase user object.
* Removed non-serializable fields like `proactiveRefresh` before dispatching to Redux.
* Ensured Redux state stays clean, serializable, and DevTools-friendly.

####  Files Changed 

* `AuthContext.tsx`
* `lib/userSlice.ts`

####  Why This Matters 

Storing non-serializable data in Redux can cause:

* Warnings in development
* Issues with Redux DevTools and time-travel debugging
* Problems with state persistence

This update ensures compliance with Redux Toolkit best practices and improves maintainability.


