### PR TITLE
[DH-88]-Fixed the problem of the not showing skills and domains in the profile card.

### DIFF
--- a/src/components/cards/ProfileSummaryCard.tsx
+++ b/src/components/cards/ProfileSummaryCard.tsx
@@ -46,8 +46,30 @@ const ProfileSummaryCard: React.FC<ProfileSummaryCardProps> = ({
     hourlyRate,
   } = profile;
 
+  // Extract a display label from various item shapes (string or object)
+  const getItemLabel = (item: any): string => {
+    if (!item) return '';
+    if (typeof item === 'string') return item;
+    if (typeof item === 'object') {
+      return (
+        item.name ||
+        item.skillName ||
+        item.domainName ||
+        item.label ||
+        item.title ||
+        item.value ||
+        item.text ||
+        ''
+      );
+    }
+    return String(item);
+  };
+
   const renderSkillBadges = (items: any[]) => {
-    if (!items || items.length === 0) {
+    const labels = (Array.isArray(items) ? items : [])
+      .map(getItemLabel)
+      .filter(Boolean);
+    if (labels.length === 0) {
       return (
         <div>
           <p className="text-sm font-medium mb-2">Skills:</p>
@@ -59,16 +81,14 @@ const ProfileSummaryCard: React.FC<ProfileSummaryCardProps> = ({
       <div>
         <p className="text-sm font-medium mb-2">Skills:</p>
         <div className="flex flex-wrap gap-1">
-          {items.slice(0, 3).map((skill: any, index: number) => (
+          {labels.slice(0, 3).map((label: string, index: number) => (
             <Badge key={index} variant="secondary" className="text-xs">
-              {typeof skill === 'string'
-                ? skill
-                : skill.name || skill.skillName}
+              {label}
             </Badge>
           ))}
-          {items.length > 3 && (
+          {labels.length > 3 && (
             <Badge variant="outline" className="text-xs">
-              +{items.length - 3} more
+              +{labels.length - 3} more
             </Badge>
           )}
         </div>
@@ -77,7 +97,10 @@ const ProfileSummaryCard: React.FC<ProfileSummaryCardProps> = ({
   };
 
   const renderDomainBadges = (items: any[]) => {
-    if (!items || items.length === 0) {
+    const labels = (Array.isArray(items) ? items : [])
+      .map(getItemLabel)
+      .filter(Boolean);
+    if (labels.length === 0) {
       return (
         <div>
           <p className="text-sm font-medium mb-2">Domains:</p>
@@ -89,16 +112,14 @@ const ProfileSummaryCard: React.FC<ProfileSummaryCardProps> = ({
       <div>
         <p className="text-sm font-medium mb-2">Domains:</p>
         <div className="flex flex-wrap gap-1">
-          {items.slice(0, 2).map((domain: any, index: number) => (
+          {labels.slice(0, 2).map((label: string, index: number) => (
             <Badge key={index} variant="outline" className="text-xs">
-              {typeof domain === 'string'
-                ? domain
-                : domain.name || domain.domainName}
+              {label}
             </Badge>
           ))}
-          {items.length > 2 && (
+          {labels.length > 2 && (
             <Badge variant="outline" className="text-xs">
-              +{items.length - 2} more
+              +{labels.length - 2} more
             </Badge>
           )}
         </div>


### PR DESCRIPTION
<img width="1919" height="1023" alt="image" src="https://github.com/user-attachments/assets/71bc2178-ed40-4e63-b7c4-bac759f8b5d3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved compatibility for skills and domains: displays correct labels whether items are strings or objects.
- Bug Fixes
  - Badge counts are now accurate; “+ N more” reflects the actual number of displayed labels.
  - Skill and domain badges render consistently, preventing mismatches between items and labels.
  - Empty or missing lists are handled gracefully, preserving “No skills added” and “No domains added” messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->