### PR TITLE
DH-115-blocked-archieved chat/user

### DIFF
--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -115,12 +115,14 @@ const HomePage = () => {
           profilePic: user.photoURL || null,
           email: user.email || null,
           userType: user.type,
+          viewState: 'inbox',
         },
         [selectedUser.id]: {
           userName: selectedUser.displayName,
           profilePic: selectedUser.profilePic || null,
           email: selectedUser.email || null,
           userType: selectedUser.userType,
+          viewState: 'inbox',
         },
       },
     };
@@ -147,12 +149,14 @@ const HomePage = () => {
             profilePic: user.photoURL || undefined,
             email: user.email || undefined,
             userType: getUserType(user.type),
+            viewState: 'inbox',
           },
           [selectedUser.id]: {
             userName: selectedUser.displayName,
             profilePic: selectedUser.profilePic || undefined,
             email: selectedUser.email || undefined,
             userType: getUserType(selectedUser.userType),
+            viewState: 'inbox',
           },
         } as const,
         createdAt: new Date().toISOString(),
@@ -193,6 +197,7 @@ const HomePage = () => {
         profilePic: user.photoURL || null,
         email: user.email || null,
         userType: user.type,
+        viewState: 'inbox',
       },
     };
     selectedUsers.forEach((selected: any) => {
@@ -201,6 +206,7 @@ const HomePage = () => {
         profilePic: selected.profilePic || null,
         email: selected.email || null,
         userType: selected.userType,
+        viewState: 'inbox',
       };
     });
 
@@ -235,6 +241,7 @@ const HomePage = () => {
               profilePic: v.profilePic || undefined,
               email: v.email || undefined,
               userType: v.userType,
+              viewState: v.viewState,
             },
           ],
         ),
@@ -392,6 +399,7 @@ const HomePage = () => {
         isChatExpanded={isChatExpanded}
         onToggleExpand={toggleChatExpanded}
         onOpenProfileSidebar={handleOpenProfileSidebar}
+        onConversationUpdate={setActiveConversation}
       />
     );
   } else if (!loading && conversations.length > 0) {
@@ -463,6 +471,7 @@ const HomePage = () => {
           profileId={profileSidebarId}
           profileType={profileSidebarType}
           initialData={profileSidebarInitialData}
+          onConversationUpdate={setActiveConversation}
         />
         {user && (
           <NewChatDialog

--- a/src/components/shared/ConfirmActionDialog.tsx
+++ b/src/components/shared/ConfirmActionDialog.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { LoaderCircle } from 'lucide-react';
 
 import {
   Dialog,
@@ -28,6 +29,7 @@ interface ConfirmActionDialogProps {
     | 'link'
     | null
     | undefined; // Optional: Default to "destructive"
+  isLoading?: boolean;
 }
 
 export function ConfirmActionDialog({
@@ -38,13 +40,16 @@ export function ConfirmActionDialog({
   description,
   confirmButtonText = 'Confirm',
   confirmButtonVariant = 'destructive',
+  isLoading = false,
 }: ConfirmActionDialogProps) {
   if (!isOpen) {
     return null;
   }
 
   const handleConfirm = () => {
+    console.log('ConfirmActionDialog handleConfirm called');
     onConfirm();
+    console.log('ConfirmActionDialog onConfirm executed');
     // onClose(); // Dialog is typically closed by the caller after onConfirm promise resolves or action completes
   };
 
@@ -87,6 +92,7 @@ export function ConfirmActionDialog({
             type="button"
             variant={confirmButtonVariant}
             onClick={handleConfirm}
+            disabled={isLoading}
             className={cn(
               confirmButtonVariant === 'destructive' &&
                 'bg-[hsl(var(--destructive))] text-[hsl(var(--destructive-foreground))] hover:bg-[hsl(var(--destructive)_/_0.9)]',
@@ -94,7 +100,11 @@ export function ConfirmActionDialog({
                 'bg-[hsl(var(--primary))] text-[hsl(var(--primary-foreground))] hover:bg-[hsl(var(--primary-hover))]',
             )}
           >
-            {confirmButtonText}
+            {isLoading ? (
+              <LoaderCircle className="h-4 w-4 animate-spin" />
+            ) : (
+              confirmButtonText
+            )}
           </Button>
         </DialogFooter>
       </DialogContent>


### PR DESCRIPTION
Added feature to block users and to archieve existing chat

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Archive/unarchive chats and switch between Inbox and Archived views with dedicated controls.
  * Block/unblock users in 1:1 chats with confirmation; blocked status shown in UI and sending disabled with clear messaging.
  * Group enhancements: Admin badges, ability to remove members, and improved handling when no members are found.
  * Confirmation dialogs now support a loading state with a spinner and disabled confirm button.
  * Improved empty and loading states for Shared Media and Shared Files.
  * Better error feedback with descriptive toasts during actions like archiving and sending messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->