### PR TITLE
talent and hire talent page add skill and domain decimal error

### DIFF
--- a/src/components/business/hireTalent.tsx/domainDiag.tsx
+++ b/src/components/business/hireTalent.tsx/domainDiag.tsx
@@ -52,7 +52,7 @@ const domainSchema = z.object({
   experience: z
     .string()
     .nonempty('Please enter your experience')
-    .regex(/^\d+$/, 'Experience must be a number')
+    .regex(/^\d+(\.\d+)?$/, 'Experience must be a number')
     .refine(
       (val) => parseInt(val) <= 40,
       'Maximum 40 years of experience allowed',

--- a/src/components/business/hireTalent.tsx/skillDiag.tsx
+++ b/src/components/business/hireTalent.tsx/skillDiag.tsx
@@ -60,7 +60,7 @@ const skillSchema = z.object({
   experience: z
     .string()
     .nonempty('Please enter your experience')
-    .regex(/^\d+$/, 'Experience must be a number')
+    .regex(/^\d+(\.\d+)?$/, 'Experience must be a number')
     .refine(
       (val) => parseInt(val) <= 40,
       'Maximum 40 years of experience allowed',

--- a/src/components/freelancer/talent/domainDiag.tsx
+++ b/src/components/freelancer/talent/domainDiag.tsx
@@ -66,7 +66,7 @@ const domainSchema = z.object({
   experience: z
     .string()
     .nonempty('Please enter your experience')
-    .regex(/^\d+$/, 'Experience must be a number'),
+    .regex(/^\d+(\.\d+)?$/, 'Experience must be a number'),
   monthlyPay: z
     .string()
     .nonempty('Please enter your monthly pay')

--- a/src/components/freelancer/talent/skillDiag.tsx
+++ b/src/components/freelancer/talent/skillDiag.tsx
@@ -64,7 +64,7 @@ const skillSchema = z.object({
   experience: z
     .string()
     .nonempty('Please enter your experience')
-    .regex(/^\d+$/, 'Experience must be a number'),
+    .regex(/^\d+(\.\d+)?$/, 'Experience must be a number'),
   monthlyPay: z
     .string()
     .nonempty('Please enter your monthly pay')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Experience input fields now accept decimal values (e.g., 2.5 years) in addition to whole numbers across talent and skill sections. This provides greater flexibility and precision when recording professional experience levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->