### PR TITLE
add spacing between navigation buttons

### DIFF
--- a/src/app/freelancer/oracleDashboard/[[...slug]]/page.tsx
+++ b/src/app/freelancer/oracleDashboard/[[...slug]]/page.tsx
@@ -53,21 +53,33 @@ export default function OracleDashboardPage() {
           className="w-full"
           data-tour="oracle"
         >
-          <TabsList className="grid w-full grid-cols-4">
-            <TabsTrigger value="business" className="flex items-center gap-2">
-              <Briefcase className="h-4 w-4" />
+          <TabsList className="grid w-full grid-cols-4 gap-2">
+            <TabsTrigger
+              value="business"
+              className="flex items-center gap-1 px-1.5 text-xs sm:text-sm sm:px-3"
+            >
+              <Briefcase className="h-3 w-3 sm:h-4 sm:w-4" />
               <span>Business</span>
             </TabsTrigger>
-            <TabsTrigger value="experience" className="flex items-center gap-2">
-              <User className="h-4 w-4" />
+            <TabsTrigger
+              value="experience"
+              className="flex items-center gap-1 px-1.5 text-xs sm:text-sm sm:px-3"
+            >
+              <User className="h-3 w-3 sm:h-4 sm:w-4" />
               <span>Experience</span>
             </TabsTrigger>
-            <TabsTrigger value="project" className="flex items-center gap-2">
-              <Package className="h-4 w-4" />
+            <TabsTrigger
+              value="project"
+              className="flex items-center gap-1 px-1.5 text-xs sm:text-sm sm:px-3"
+            >
+              <Package className="h-3 w-3 sm:h-4 sm:w-4" />
               <span>Projects</span>
             </TabsTrigger>
-            <TabsTrigger value="education" className="flex items-center gap-2">
-              <BookOpen className="h-4 w-4" />
+            <TabsTrigger
+              value="education"
+              className="flex items-center gap-1 px-1.5 text-xs sm:text-sm sm:px-3"
+            >
+              <BookOpen className="h-3 w-3 sm:h-4 sm:w-4" />
               <span>Education</span>
             </TabsTrigger>
           </TabsList>


### PR DESCRIPTION
Added spacing between navigation buttons for better readability.
<img width="1365" height="676" alt="Screenshot 2026-02-09 210627" src="https://github.com/user-attachments/assets/c299c981-e9be-4522-b036-79c82c8f28e6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined Oracle Dashboard tab bar spacing and layout with enhanced responsive design.
  * Optimized tab trigger sizing, text rendering, and icon dimensions to adapt across various screen sizes.
  * Improved visual consistency while maintaining existing tab functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->