### PR TITLE
DHB-175: Fix duplicate skill/domain filters

### DIFF
--- a/src/app/business/talent/page.tsx
+++ b/src/app/business/talent/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+
 import { usePathname, useRouter } from 'next/navigation';
 import { Users2, FileText } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -168,7 +169,7 @@ export default function Talent() {
           }
         });
       const fetchedFilterSkills: Skill[] = Array.from(skillsMap.values());
-      
+
       // Deduplicate domains by label using Map for O(n) performance
       const domainsMap = new Map<string, Domain>();
       hires
@@ -324,7 +325,7 @@ export default function Talent() {
             </Select>
           </div>
           <div
-            className="lg:h-[75vh] h-[59vh] rounded-lg  overflow-y-scroll no-scrollbar"
+            className="lg:h-[75vh] h-[59vh] rounded-lg overflow-y-scroll no-scrollbar"
             data-tour="business-talent-list"
           >
             <TalentCard

--- a/src/app/business/talent/page.tsx
+++ b/src/app/business/talent/page.tsx
@@ -99,21 +99,31 @@ export default function Talent() {
       setDomains(nextDomains);
       setHireItems(nextHires);
 
-      const fetchedFilterSkills: Skill[] = (nextHires || [])
+      // Deduplicate skills by label using Map for O(n) performance
+      const skillsMap = new Map<string, Skill>();
+      (nextHires || [])
         .filter((item) => item?.type === 'SKILL' && item?.visible)
-        .map((item) => ({
-          _id: item?.talentId || item?._id,
-          label: item?.talentName || '',
-        }))
-        .filter((s) => Boolean(s._id) && Boolean(s.label));
+        .forEach((item) => {
+          const label = item?.talentName || '';
+          const _id = item?.talentId || item?._id;
+          if (label && _id && !skillsMap.has(label)) {
+            skillsMap.set(label, { _id, label });
+          }
+        });
+      const fetchedFilterSkills: Skill[] = Array.from(skillsMap.values());
 
-      const fetchedFilterDomains: Domain[] = (nextHires || [])
+      // Deduplicate domains by label using Map for O(n) performance
+      const domainsMap = new Map<string, Domain>();
+      (nextHires || [])
         .filter((item) => item?.type === 'DOMAIN' && item?.visible)
-        .map((item) => ({
-          _id: item?.talentId || item?._id,
-          label: item?.talentName || '',
-        }))
-        .filter((d) => Boolean(d._id) && Boolean(d.label));
+        .forEach((item) => {
+          const label = item?.talentName || '';
+          const _id = item?.talentId || item?._id;
+          if (label && _id && !domainsMap.has(label)) {
+            domainsMap.set(label, { _id, label });
+          }
+        });
+      const fetchedFilterDomains: Domain[] = Array.from(domainsMap.values());
 
       setFilterSkill(fetchedFilterSkills);
       setFilterDomain(fetchedFilterDomains);
@@ -146,20 +156,31 @@ export default function Talent() {
       setHireItems(cachedBusinessTalentBootstrap.hires);
 
       const hires = cachedBusinessTalentBootstrap.hires || [];
-      const fetchedFilterSkills: Skill[] = hires
+      // Deduplicate skills by label using Map for O(n) performance
+      const skillsMap = new Map<string, Skill>();
+      hires
         .filter((item) => item?.type === 'SKILL' && item?.visible)
-        .map((item) => ({
-          _id: item?.talentId || item?._id,
-          label: item?.talentName || '',
-        }))
-        .filter((s) => Boolean(s._id) && Boolean(s.label));
-      const fetchedFilterDomains: Domain[] = hires
+        .forEach((item) => {
+          const label = item?.talentName || '';
+          const _id = item?.talentId || item?._id;
+          if (label && _id && !skillsMap.has(label)) {
+            skillsMap.set(label, { _id, label });
+          }
+        });
+      const fetchedFilterSkills: Skill[] = Array.from(skillsMap.values());
+      
+      // Deduplicate domains by label using Map for O(n) performance
+      const domainsMap = new Map<string, Domain>();
+      hires
         .filter((item) => item?.type === 'DOMAIN' && item?.visible)
-        .map((item) => ({
-          _id: item?.talentId || item?._id,
-          label: item?.talentName || '',
-        }))
-        .filter((d) => Boolean(d._id) && Boolean(d.label));
+        .forEach((item) => {
+          const label = item?.talentName || '';
+          const _id = item?.talentId || item?._id;
+          if (label && _id && !domainsMap.has(label)) {
+            domainsMap.set(label, { _id, label });
+          }
+        });
+      const fetchedFilterDomains: Domain[] = Array.from(domainsMap.values());
       setFilterSkill(fetchedFilterSkills);
       setFilterDomain(fetchedFilterDomains);
 

--- a/src/components/business/hireTalent.tsx/skillDomainForm.tsx
+++ b/src/components/business/hireTalent.tsx/skillDomainForm.tsx
@@ -138,19 +138,31 @@ const SkillDomainForm: React.FC<SkillDomainFormProps> = ({
         );
         const hireTalentData = hireTalentResponse.data?.data || [];
 
-        const fetchedFilterSkills = (hireTalentData || [])
+        // Deduplicate skills by label using Map for O(n) performance
+        const skillsMap = new Map<string, Skill>();
+        (hireTalentData || [])
           .filter((item: any) => item.type === 'SKILL' && item.visible)
-          .map((item: any) => ({
-            _id: item.talentId || item._id,
-            label: item.talentName,
-          }));
+          .forEach((item: any) => {
+            const label = item.talentName || '';
+            const _id = item.talentId || item._id;
+            if (label && _id && !skillsMap.has(label)) {
+              skillsMap.set(label, { _id, label });
+            }
+          });
+        const fetchedFilterSkills = Array.from(skillsMap.values());
 
-        const fetchedFilterDomains = (hireTalentData || [])
+        // Deduplicate domains by label using Map for O(n) performance
+        const domainsMap = new Map<string, Domain>();
+        (hireTalentData || [])
           .filter((item: any) => item.type === 'DOMAIN' && item.visible)
-          .map((item: any) => ({
-            _id: item.talentId || item._id,
-            label: item.talentName,
-          }));
+          .forEach((item: any) => {
+            const label = item.talentName || '';
+            const _id = item.talentId || item._id;
+            if (label && _id && !domainsMap.has(label)) {
+              domainsMap.set(label, { _id, label });
+            }
+          });
+        const fetchedFilterDomains = Array.from(domainsMap.values());
 
         setFilterSkill(fetchedFilterSkills);
         setFilterDomain(fetchedFilterDomains);

--- a/src/components/business/hireTalent.tsx/talentCard.tsx
+++ b/src/components/business/hireTalent.tsx/talentCard.tsx
@@ -201,21 +201,31 @@ const TalentCard: React.FC<TalentCardProps> = ({
         const res = await axiosInstance.get('/business/hire-dehixtalent');
         const hireTalentData = res?.data?.data || [];
 
-        const filterSkills: SkillOption[] = (hireTalentData || [])
+        // Deduplicate skills by label using Map for O(n) performance
+        const skillsMap = new Map<string, SkillOption>();
+        (hireTalentData || [])
           .filter((item: any) => item?.type === 'SKILL' && item?.visible)
-          .map((item: any) => ({
-            _id: item?.talentId || item?._id,
-            label: item?.talentName || '',
-          }))
-          .filter((s: any) => Boolean(s?._id) && Boolean(s?.label));
+          .forEach((item: any) => {
+            const label = item?.talentName || '';
+            const _id = item?.talentId || item?._id;
+            if (label && _id && !skillsMap.has(label)) {
+              skillsMap.set(label, { _id, label });
+            }
+          });
+        const filterSkills: SkillOption[] = Array.from(skillsMap.values());
 
-        const filterDomains: DomainOption[] = (hireTalentData || [])
+        // Deduplicate domains by label using Map for O(n) performance
+        const domainsMap = new Map<string, DomainOption>();
+        (hireTalentData || [])
           .filter((item: any) => item?.type === 'DOMAIN' && item?.visible)
-          .map((item: any) => ({
-            _id: item?.talentId || item?._id,
-            label: item?.talentName || '',
-          }))
-          .filter((d: any) => Boolean(d?._id) && Boolean(d?.label));
+          .forEach((item: any) => {
+            const label = item?.talentName || '';
+            const _id = item?.talentId || item?._id;
+            if (label && _id && !domainsMap.has(label)) {
+              domainsMap.set(label, { _id, label });
+            }
+          });
+        const filterDomains: DomainOption[] = Array.from(domainsMap.values());
 
         const formatted: SkillDomainData[] = (hireTalentData || [])
           .map((item: any) => ({

--- a/src/components/freelancer/project/projectProfileDetailCard.tsx
+++ b/src/components/freelancer/project/projectProfileDetailCard.tsx
@@ -56,21 +56,18 @@ export function ProjectProfileDetailCard({
   skills,
   experience,
   minConnect,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   description,
   email,
   status,
   startDate,
   endDate,
   className,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   domain_id,
   ...props
 }: CardProps) {
   const user = useSelector((state: RootState) => state.user);
   const router = useRouter();
   const params = useParams();
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [bidProfiles, setBidProfiles] = React.useState<string[]>([]); // Store profile IDs from API
   const [exist, setExist] = useState(false);
   const [hasReachedLimit, setHasReachedLimit] = useState(false);

--- a/src/components/freelancer/project/projectProfileDetailCard.tsx
+++ b/src/components/freelancer/project/projectProfileDetailCard.tsx
@@ -56,18 +56,21 @@ export function ProjectProfileDetailCard({
   skills,
   experience,
   minConnect,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   description,
   email,
   status,
   startDate,
   endDate,
   className,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   domain_id,
   ...props
 }: CardProps) {
   const user = useSelector((state: RootState) => state.user);
   const router = useRouter();
   const params = useParams();
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [bidProfiles, setBidProfiles] = React.useState<string[]>([]); // Store profile IDs from API
   const [exist, setExist] = useState(false);
   const [hasReachedLimit, setHasReachedLimit] = useState(false);


### PR DESCRIPTION

<img width="1911" height="967" alt="image" src="https://github.com/user-attachments/assets/df9565cd-e8b5-4a05-b18c-610c82d14db7" />


## Changes
- Fixed the Talent filter section, the skills was displayed multiple times instead of appearing once.

Now Each skill shows only once in the filter list.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data handling in the talent hiring interface to eliminate duplicate skills and domains appearing in profile displays, filter selections, and talent cards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->