### PR TITLE
Fix: Linkedin url for business sign up

### DIFF
--- a/src/components/form/businessForm.tsx
+++ b/src/components/form/businessForm.tsx
@@ -45,6 +45,9 @@ import { Type } from '@/utils/enum';
 import { setUser } from '@/lib/userSlice';
 import { notifyError, notifySuccess } from '@/utils/toastMessage';
 
+const LINKEDIN_REGEX =
+  /^https:\/\/([a-z]{2,3}\.)?linkedin\.com\/(in|company)\/[a-zA-Z0-9-_%]+\/?$/;
+
 const profileFormSchema = z.object({
   firstName: z.string().min(2, {
     message: 'First Name must be at least 2 characters.',
@@ -66,10 +69,9 @@ const profileFormSchema = z.object({
     .url({ message: 'Must be a valid URL.' })
     .refine(
       (url) =>
-        url.includes('linkedin.com/in/') ||
-        url.includes('linkedin.com/company/'),
+        url || LINKEDIN_REGEX.test(url),
       {
-        message: 'LinkedIn URL must start with: https://www.linkedin.com/in/',
+        message: 'Enter a valid LinkedIn profile or company page URL',
       },
     )
     .optional(),

--- a/src/components/form/businessForm.tsx
+++ b/src/components/form/businessForm.tsx
@@ -67,7 +67,7 @@ const profileFormSchema = z.object({
   linkedin: z
     .string()
     .url({ message: 'Must be a valid URL.' })
-    .refine((url) => url || LINKEDIN_REGEX.test(url), {
+    .refine((url) => !url || LINKEDIN_REGEX.test(url), {
       message: 'Enter a valid LinkedIn profile or company page URL',
     })
     .optional(),

--- a/src/components/form/businessForm.tsx
+++ b/src/components/form/businessForm.tsx
@@ -91,7 +91,7 @@ export function BusinessForm({ user_id }: { user_id: string }) {
       companyName: '',
       companySize: '',
       position: '',
-      linkedin: '',
+      linkedin: undefined,
       website: '',
     },
     mode: 'all',

--- a/src/components/form/businessForm.tsx
+++ b/src/components/form/businessForm.tsx
@@ -67,13 +67,9 @@ const profileFormSchema = z.object({
   linkedin: z
     .string()
     .url({ message: 'Must be a valid URL.' })
-    .refine(
-      (url) =>
-        url || LINKEDIN_REGEX.test(url),
-      {
-        message: 'Enter a valid LinkedIn profile or company page URL',
-      },
-    )
+    .refine((url) => url || LINKEDIN_REGEX.test(url), {
+      message: 'Enter a valid LinkedIn profile or company page URL',
+    })
     .optional(),
   website: z.string().url({ message: 'Must be a valid URL.' }).optional(),
 });

--- a/src/components/form/register/business.tsx
+++ b/src/components/form/register/business.tsx
@@ -187,14 +187,9 @@ const businessRegisterSchema = z
       .string()
       .url('Invalid URL')
       .optional()
-      .refine(
-        (value) =>
-          !value || LINKEDIN_REGEX.test(value),
-        {
-          message:
-            'Enter a valid LinkedIn profile or company page URL',
-        },
-      ),
+      .refine((value) => !value || LINKEDIN_REGEX.test(value), {
+        message: 'Enter a valid LinkedIn profile or company page URL',
+      }),
     personalWebsite: z
       .string()
       .optional()

--- a/src/components/form/register/business.tsx
+++ b/src/components/form/register/business.tsx
@@ -169,6 +169,9 @@ const Stepper = ({ currentStep = 0 }: StepperProps) => {
   );
 };
 
+const LINKEDIN_REGEX =
+  /^https:\/\/([a-z]{2,3}\.)?linkedin\.com\/(in|company)\/[a-zA-Z0-9-_%]+\/?$/;
+
 const businessRegisterSchema = z
   .object({
     firstName: z.string().min(1, 'First name is required'),
@@ -186,11 +189,10 @@ const businessRegisterSchema = z
       .optional()
       .refine(
         (value) =>
-          !value ||
-          /^https:\/\/www\.linkedin\.com\/in\/[a-zA-Z0-9_-]+\/?$/.test(value),
+          !value || LINKEDIN_REGEX.test(value),
         {
           message:
-            'LinkedIn URL must start with "https://www.linkedin.com/in/" and have a valid username',
+            'Enter a valid LinkedIn profile or company page URL',
         },
       ),
     personalWebsite: z
@@ -765,7 +767,7 @@ function BusinessRegisterForm({
                           </InputGroupText>
                           <InputGroupInput
                             type="url"
-                            placeholder="https://www.linkedin.com/in/username"
+                            placeholder="https://www.linkedin.com"
                             {...field}
                             value={field.value ?? ''}
                           />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistently validate LinkedIn URLs to accept both profile and company pages.
  * Allow the LinkedIn field to be left empty or contain a valid URL.
  * Clarified validation error message: "Enter a valid LinkedIn profile or company page URL".
  * Updated LinkedIn input placeholder to show a generic base URL format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->