### PR TITLE
fix: Remove add button from single-entry sections

### DIFF
--- a/src/components/form/resumeform/EducationInfo.tsx
+++ b/src/components/form/resumeform/EducationInfo.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { GraduationCap, X, School } from 'lucide-react';
 
-import { AddButton } from '@/components/ui/AddButton';
 import { cn } from '@/lib/utils';
 import { Label } from '@/components/ui/label';
 import {
@@ -44,13 +43,6 @@ export const EducationInfo: React.FC<EducationInfoProps> = ({
     const updatedEducation = [...educationData];
     updatedEducation[index] = { ...updatedEducation[index], [field]: value };
     setEducationData(updatedEducation);
-  };
-
-  const handleAddEducation = () => {
-    setEducationData([
-      ...educationData,
-      { degree: '', school: '', startDate: '', endDate: '' },
-    ]);
   };
 
   const handleRemoveEducation = (index: number) => {
@@ -156,8 +148,6 @@ export const EducationInfo: React.FC<EducationInfoProps> = ({
           </Card>
         ))}
       </form>
-
-      <AddButton onClick={handleAddEducation} />
     </div>
   );
 };

--- a/src/components/form/resumeform/PersonalInfo.tsx
+++ b/src/components/form/resumeform/PersonalInfo.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { User, X, Mail, Phone, MapPin, Github, Linkedin } from 'lucide-react';
 
-import { AddButton } from '@/components/ui/AddButton';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import {
@@ -47,22 +46,6 @@ export const PersonalInfo: React.FC<PersonalInfoProps> = ({
       [field]: value,
     };
     setPersonalData(updatedPersonalData);
-  };
-
-  const handleAddPersonalInfo = () => {
-    setPersonalData([
-      ...personalData,
-      {
-        firstName: '',
-        lastName: '',
-        city: '',
-        country: '',
-        phoneNumber: '',
-        email: '',
-        github: '',
-        linkedin: '',
-      },
-    ]);
   };
 
   const handleRemovePersonalInfo = (index: number) => {
@@ -249,7 +232,6 @@ export const PersonalInfo: React.FC<PersonalInfoProps> = ({
           </Card>
         ))}
       </form>
-      <AddButton onClick={handleAddPersonalInfo} />
     </div>
   );
 };

--- a/src/components/form/resumeform/SummaryInfo.tsx
+++ b/src/components/form/resumeform/SummaryInfo.tsx
@@ -2,7 +2,6 @@ import React, { useEffect } from 'react';
 // import { useForm } from 'react-hook-form';
 import { NotebookText, X } from 'lucide-react';
 
-import { AddButton } from '@/components/ui/AddButton';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import {
@@ -44,10 +43,6 @@ export const SummaryInfo: React.FC<SummaryInfoProps> = ({
   };
 
   useEffect(() => {}, [workExperienceData]); // Logs data every time it updates
-
-  const handleAddSummary = () => {
-    setSummaryData([...summaryData, '']);
-  };
 
   const handleRemoveSummary = (index: number) => {
     const updatedSummaryData = summaryData.filter((_, i) => i !== index);
@@ -142,8 +137,6 @@ export const SummaryInfo: React.FC<SummaryInfoProps> = ({
           </Card>
         ))}
       </form>
-
-      <AddButton onClick={handleAddSummary} />
 
       {/* <div className="flex justify-center mt-4">
         <Button className="text-center bg-green-500 hover:bg-green-600 text-white">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the ability to add new entries in the Education, Personal Info, and Summary sections of the resume form. Users can now only edit and delete existing entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->