### PR TITLE
fix: project thumbnail label

### DIFF
--- a/src/components/dialogs/editProjectDialog.tsx
+++ b/src/components/dialogs/editProjectDialog.tsx
@@ -344,7 +344,6 @@ const EditProjectDialog: React.FC<EditProjectDialogProps> = ({
               name="thumbnail"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Project Thumbnail</FormLabel>
                   <FormControl>
                     <ThumbnailUpload
                       onThumbnailUpdate={(url) => field.onChange(url)}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed the "Project Thumbnail" label from the thumbnail upload field in the Edit Project dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->