### PR TITLE
Dhb192 and dhb-194

### DIFF
--- a/src/components/marketComponents/TalentContent.tsx
+++ b/src/components/marketComponents/TalentContent.tsx
@@ -4,7 +4,6 @@ import React, { useEffect, useState } from 'react';
 import { Loader2, Search, Sliders, X } from 'lucide-react';
 
 import InvitedProfileCards from './sidebar-projectComponents/profileCards.tsx/invitedProfileCards';
-import AcceptedProfileCards from './sidebar-projectComponents/profileCards.tsx/acceptedProfileCards';
 import RejectedProfileCards from './sidebar-projectComponents/profileCards.tsx/rejectedProfileCards';
 
 import { calculateExperience } from '@/components/marketComponents/TalentLayout'; //
@@ -216,20 +215,13 @@ const TalentContent: React.FC<TalentContentProps> = ({
         onStatusFilterChange?.(undefined);
       };
       const cards =
-        selected === 'accepted' ? (
-          <AcceptedProfileCards
-            talents={talents}
-            loading={loading}
-            calculateExperience={calculateExperience}
-          />
-        ) : selected === 'rejected' ? (
+        selected === 'rejected' ? (
           <RejectedProfileCards
             talents={talents}
             loading={loading}
             calculateExperience={calculateExperience}
           />
         ) : (
-          // invited + applications (applied) share the same card layout today
           <InvitedProfileCards
             talents={talents}
             loading={loading}

--- a/src/components/resumeEditor/ResumePreview1.tsx
+++ b/src/components/resumeEditor/ResumePreview1.tsx
@@ -66,6 +66,19 @@ export const ResumePreview1: React.FC<ResumePreviewProps> = ({
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
 
+  const formatDate = (dateString: string) => {
+    if (!dateString) return '';
+    try {
+      return new Date(dateString).toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      });
+    } catch {
+      return dateString;
+    }
+  };
+
   return (
     <div className="flex justify-center w-full h-full rounded-md">
       <div
@@ -130,7 +143,7 @@ export const ResumePreview1: React.FC<ResumePreviewProps> = ({
                   {item.jobTitle} - {item.company}
                 </p>
                 <p className="text-xs text-gray-700">
-                  {item.startDate} to {item.endDate}
+                  {formatDate(item.startDate)} to {formatDate(item.endDate)}
                 </p>
                 <p className="text-sm text-gray-800 leading-relaxed mt-1">
                   {item.description}
@@ -155,7 +168,7 @@ export const ResumePreview1: React.FC<ResumePreviewProps> = ({
                   {item.degree} - {item.school}
                 </p>
                 <p className="text-xs text-gray-700">
-                  {item.startDate} to {item.endDate}
+                  {formatDate(item.startDate)} to {formatDate(item.endDate)}
                 </p>
               </div>
             ))}

--- a/src/components/resumeEditor/ResumePreview2.tsx
+++ b/src/components/resumeEditor/ResumePreview2.tsx
@@ -94,6 +94,19 @@ export const ResumePreview2: React.FC<ResumePreviewProps> = ({
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
 
+  const formatDate = (dateString: string) => {
+    if (!dateString) return '';
+    try {
+      return new Date(dateString).toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      });
+    } catch {
+      return dateString;
+    }
+  };
+
   return (
     <div className="flex justify-center w-full h-full rounded-md">
       <div
@@ -195,7 +208,7 @@ export const ResumePreview2: React.FC<ResumePreviewProps> = ({
                         {exp.jobTitle}
                       </h3>
                       <span className="text-xs text-gray-500 whitespace-nowrap ml-2">
-                        {exp.startDate} - {exp.endDate}
+                        {formatDate(exp.startDate)} - {formatDate(exp.endDate)}
                       </span>
                     </div>
                     <p className="text-xs font-medium text-gray-700 mb-1">
@@ -247,7 +260,7 @@ export const ResumePreview2: React.FC<ResumePreviewProps> = ({
                       {edu.degree}
                     </h3>
                     <span className="text-xs text-gray-500 whitespace-nowrap ml-2">
-                      {edu.startDate} - {edu.endDate}
+                      {formatDate(edu.startDate)} - {formatDate(edu.endDate)}
                     </span>
                   </div>
                   <p className="text-xs text-gray-700">{edu.school}</p>


### PR DESCRIPTION
Dates in the Experience and Education sections should be displayed in the correct and consistent
format.
Freelancer profile cards should have the same UI and layout for both Invited and Accepted statuses.
<img width="1440" height="900" alt="Screenshot 2026-02-23 at 9 09 06 PM" src="https://github.com/user-attachments/assets/cbb04fad-2374-42d8-8afa-c34227f04324" />
<img width="1440" height="900" alt="Screenshot 2026-02-24 at 4 58 32 PM" src="https://github.com/user-attachments/assets/f8a6319b-cb5c-46af-a9f4-eef318622238" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced date display formatting in resume preview sections (Work Experience and Education) for consistent presentation with fallback error handling for parsing failures.

* **Refactor**
  * Streamlined card rendering logic in the applications view by simplifying conditional branching for more efficient profile card display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->