### PR TITLE
fix(DHB-195): Resume PDF format, clickable links & layout improvements

### DIFF
--- a/src/components/resumeEditor/ResumePreview1.tsx
+++ b/src/components/resumeEditor/ResumePreview1.tsx
@@ -5,6 +5,38 @@ import React, { useRef } from 'react';
 // import { cn } from '@/lib/utils';
 import { Separator } from '@/components/ui/separator';
 
+// Normalises a raw string into an openable href
+const toHref = (value: string): string => {
+  if (!value) return '#';
+  const v = value.trim();
+  if (/^mailto:/i.test(v) || /^https?:\/\//i.test(v) || /^tel:/i.test(v))
+    return v;
+  if (/^[\w.+-]+@[\w-]+\.[a-z]{2,}$/i.test(v)) return `mailto:${v}`;
+  if (/^\+?[\d\s\-().]{7,}$/.test(v)) return `tel:${v.replace(/\s/g, '')}`;
+  // github / linkedin paths or full URLs
+  if (/github\.com|linkedin\.com/i.test(v))
+    return v.startsWith('http') ? v : `https://${v}`;
+  return v.startsWith('http') ? v : `https://${v}`;
+};
+
+const ResumeLink: React.FC<{ value: string; label?: string }> = ({
+  value,
+  label,
+}) => {
+  if (!value) return null;
+  return (
+    <a
+      href={toHref(value)}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="hover:underline hover:text-blue-600 transition-colors duration-150 cursor-pointer"
+      style={{ color: 'inherit' }}
+    >
+      {label || value}
+    </a>
+  );
+};
+
 interface SectionVisibility {
   personal: boolean;
   summary: boolean;
@@ -36,6 +68,8 @@ interface ResumePreviewProps {
     email: string;
     github: string;
     linkedin: string;
+    city?: string;
+    country?: string;
   }[];
   projectData?: { title: string; description: string }[];
   skillData?: { skillName: string }[];
@@ -91,7 +125,7 @@ export const ResumePreview1: React.FC<ResumePreviewProps> = ({
           boxSizing: 'border-box',
         }}
       >
-        <div className="w-full text-center mb-2">
+        <div className="w-full text-center mb-4">
           {sectionVisibility.personal &&
             personalData.map((person, index) => (
               <div key={index}>
@@ -101,11 +135,29 @@ export const ResumePreview1: React.FC<ResumePreviewProps> = ({
                 >
                   {`${person.firstName} ${person.lastName}`}
                 </h1>
-                <p className="text-sm text-gray-800 leading-tight">
-                  {person.email} • {person.phoneNumber}
+                <p className="text-sm text-gray-800 leading-tight flex flex-wrap justify-center gap-x-2">
+                  <ResumeLink value={person.email} />
+                  <span className="select-none">—</span>
+                  <span>{person.phoneNumber}</span>
+                  {(person.city || person.country) && (
+                    <>
+                      <span className="select-none">—</span>
+                      <span>{[person.city, person.country].filter(Boolean).join(', ')}</span>
+                    </>
+                  )}
                 </p>
-                <p className="text-sm text-gray-800 leading-tight">
-                  {person.github} • {person.linkedin}
+                <p className="text-sm text-gray-800 leading-tight flex flex-wrap justify-center gap-x-2">
+                  {person.github && (
+                    <>
+                      <ResumeLink value={person.github} label="GitHub" />
+                      <span className="select-none">—</span>
+                    </>
+                  )}
+                  {person.linkedin && (
+                    <>
+                      <ResumeLink value={person.linkedin} label="LinkedIn" />
+                    </>
+                  )}
                 </p>
               </div>
             ))}
@@ -114,7 +166,7 @@ export const ResumePreview1: React.FC<ResumePreviewProps> = ({
         <Separator className="bg-gray-300 my-2" />
 
         {sectionVisibility.summary && summaryData.length > 0 && (
-          <div className="mb-3">
+          <div className="mb-4">
             <h2
               className="text-lg font-semibold text-gray-900 mb-1"
               style={{ color: headingColor }}
@@ -129,14 +181,14 @@ export const ResumePreview1: React.FC<ResumePreviewProps> = ({
         )}
 
         {sectionVisibility.workExperience && workExperienceData.length > 0 && (
-          <div className="mb-3">
+          <div className="mb-4">
             <h2
               className="text-lg font-semibold text-gray-900 mb-2"
               style={{ color: headingColor }}
             >
               Work Experience
             </h2>
-            <Separator className="mb-2 bg-gray-300" />
+            <Separator className="mb-3 bg-gray-300" />
             {workExperienceData.map((item, index) => (
               <div key={index} className="mb-3">
                 <p className="text-sm font-medium text-gray-900">
@@ -183,7 +235,7 @@ export const ResumePreview1: React.FC<ResumePreviewProps> = ({
             >
               Projects
             </h2>
-            <Separator className="mb-2 bg-gray-300" />
+            <Separator className="mb-3 bg-gray-300" />
             {projectData.map((project, index) => (
               <div key={index} className="mb-3">
                 <p className="text-sm font-medium text-gray-900">
@@ -203,8 +255,8 @@ export const ResumePreview1: React.FC<ResumePreviewProps> = ({
             >
               Skills
             </h2>
-            <Separator className="mb-2 bg-gray-300" />
-            <ul className="list-disc list-inside text-sm text-gray-800">
+            <Separator className="mb-3 bg-gray-300" />
+            <ul className="list-disc list-inside text-sm text-gray-800 sm:columns-2 sm:gap-x-6 [&>li]:break-inside-avoid">
               {skillData.map((skill, index) => (
                 <li key={index}>{skill.skillName}</li>
               ))}
@@ -220,8 +272,8 @@ export const ResumePreview1: React.FC<ResumePreviewProps> = ({
             >
               Achievements
             </h2>
-            <Separator className="mb-2 bg-gray-300" />
-            <ul className="list-disc list-inside text-sm text-gray-800">
+            <Separator className="mb-3 bg-gray-300" />
+            <ul className="list-disc list-inside text-sm text-gray-800 sm:columns-2 sm:gap-x-6 [&>li]:break-inside-avoid">
               {achievementData.map((achievement, index) => (
                 <li key={index}>{achievement.achievementName}</li>
               ))}

--- a/src/components/resumeEditor/ResumePreview1.tsx
+++ b/src/components/resumeEditor/ResumePreview1.tsx
@@ -136,28 +136,61 @@ export const ResumePreview1: React.FC<ResumePreviewProps> = ({
                   {`${person.firstName} ${person.lastName}`}
                 </h1>
                 <p className="text-sm text-gray-800 leading-tight flex flex-wrap justify-center gap-x-2">
-                  <ResumeLink value={person.email} />
-                  <span className="select-none">—</span>
-                  <span>{person.phoneNumber}</span>
-                  {(person.city || person.country) && (
-                    <>
-                      <span className="select-none">—</span>
-                      <span>{[person.city, person.country].filter(Boolean).join(', ')}</span>
-                    </>
-                  )}
+                  {[
+                    person.email ? (
+                      <ResumeLink key="email" value={person.email} />
+                    ) : null,
+                    person.phoneNumber ? (
+                      <span key="phone">{person.phoneNumber}</span>
+                    ) : null,
+                    person.city || person.country ? (
+                      <span key="location">
+                        {[person.city, person.country]
+                          .filter(Boolean)
+                          .join(', ')}
+                      </span>
+                    ) : null,
+                  ]
+                    .filter(Boolean)
+                    .reduce<React.ReactNode[]>((acc, el, i) => {
+                      if (i > 0)
+                        acc.push(
+                          <span key={`sep-${i}`} className="select-none">
+                            —
+                          </span>,
+                        );
+                      acc.push(el);
+                      return acc;
+                    }, [])}
                 </p>
                 <p className="text-sm text-gray-800 leading-tight flex flex-wrap justify-center gap-x-2">
-                  {person.github && (
-                    <>
-                      <ResumeLink value={person.github} label="GitHub" />
-                      <span className="select-none">—</span>
-                    </>
-                  )}
-                  {person.linkedin && (
-                    <>
-                      <ResumeLink value={person.linkedin} label="LinkedIn" />
-                    </>
-                  )}
+                  {[
+                    person.github ? (
+                      <ResumeLink
+                        key="github"
+                        value={person.github}
+                        label="GitHub"
+                      />
+                    ) : null,
+                    person.linkedin ? (
+                      <ResumeLink
+                        key="linkedin"
+                        value={person.linkedin}
+                        label="LinkedIn"
+                      />
+                    ) : null,
+                  ]
+                    .filter(Boolean)
+                    .reduce<React.ReactNode[]>((acc, el, i) => {
+                      if (i > 0)
+                        acc.push(
+                          <span key={`sep-${i}`} className="select-none">
+                            —
+                          </span>,
+                        );
+                      acc.push(el);
+                      return acc;
+                    }, [])}
                 </p>
               </div>
             ))}

--- a/src/components/resumeEditor/ResumePreview2.tsx
+++ b/src/components/resumeEditor/ResumePreview2.tsx
@@ -2,6 +2,37 @@ import React, { useRef } from 'react';
 
 // import { cn } from '@/lib/utils';
 import { Separator } from '@/components/ui/separator';
+
+const toHref = (value: string): string => {
+  if (!value) return '#';
+  const v = value.trim();
+  if (/^mailto:/i.test(v) || /^https?:\/\//i.test(v) || /^tel:/i.test(v))
+    return v;
+  if (/^[\w.+-]+@[\w-]+\.[a-z]{2,}$/i.test(v)) return `mailto:${v}`;
+  if (/^\+?[\d\s\-().]{7,}$/.test(v)) return `tel:${v.replace(/\s/g, '')}`;
+  if (/github\.com|linkedin\.com/i.test(v))
+    return v.startsWith('http') ? v : `https://${v}`;
+  return v.startsWith('http') ? v : `https://${v}`;
+};
+
+const ResumeLink: React.FC<{ value: string; label?: string }> = ({
+  value,
+  label,
+}) => {
+  if (!value) return null;
+  const href = toHref(value);
+  const isLocal = href.startsWith('mailto:') || href.startsWith('tel:');
+  return (
+    <a
+      href={href}
+      {...(!isLocal && { target: '_blank', rel: 'noopener noreferrer' })}
+      className="hover:underline hover:text-blue-600 transition-colors duration-150 cursor-pointer"
+      style={{ color: 'inherit' }}
+    >
+      {label || value}
+    </a>
+  );
+};
 // Add this interface near the top of both files
 interface SectionVisibility {
   personal: boolean;
@@ -34,6 +65,8 @@ interface ResumePreviewProps {
     email: string;
     github: string;
     linkedin: string;
+    city?: string;
+    country?: string;
   }[];
   projectData?: { title: string; description: string }[];
   skillData?: { skillName: string }[];
@@ -60,7 +93,7 @@ export const ResumePreview2: React.FC<ResumePreviewProps> = ({
   ],
   workExperienceData = [
     {
-      jobTitle: 'english teacher',
+      jobTitle: 'English Teacher',
       company: 'TechCorp Solutions',
       startDate: '2019',
       endDate: '2021',
@@ -68,7 +101,7 @@ export const ResumePreview2: React.FC<ResumePreviewProps> = ({
         'Developed scalable web applications and optimized system performance.',
     },
     {
-      jobTitle: 'Sql developer',
+      jobTitle: 'SQL Developer',
       company: 'Innovatech',
       startDate: '2021',
       endDate: '2023',
@@ -96,22 +129,24 @@ export const ResumePreview2: React.FC<ResumePreviewProps> = ({
 
   const formatDate = (dateString: string) => {
     if (!dateString) return '';
-    try {
-      return new Date(dateString).toLocaleDateString('en-US', {
-        year: 'numeric',
-        month: 'short',
-        day: 'numeric',
-      });
-    } catch {
-      return dateString;
-    }
+    if (/^\d{4}$/.test(dateString.trim())) return dateString.trim();
+    const parts = dateString.trim().match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    const d = parts
+      ? new Date(Date.UTC(+parts[1], +parts[2] - 1, +parts[3]))
+      : new Date(dateString);
+    if (isNaN(d.getTime())) return dateString;
+    return d.toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      timeZone: 'UTC',
+    });
   };
 
   return (
     <div className="flex justify-center w-full h-full rounded-md">
       <div
         ref={containerRef}
-        className="bg-white w-full max-w-[794px] flex rounded-md overflow-hidden  border border-gray-300"
+        className="bg-white w-full max-w-[794px] flex rounded-md overflow-hidden border border-gray-300"
         style={{
           boxShadow: '0px 4px 10px rgba(0, 0, 0, 0.05)',
           minHeight: '297mm',
@@ -123,7 +158,7 @@ export const ResumePreview2: React.FC<ResumePreviewProps> = ({
         <div className="w-1/3 bg-white p-5 flex flex-col">
           {sectionVisibility.personal &&
             personalData.map((person, index) => (
-              <div key={index} className="mb-3">
+              <div key={index} className="mb-4">
                 <h1
                   className="text-2xl font-bold text-gray-900 mb-2"
                   style={{ color: headingColor }}
@@ -139,24 +174,29 @@ export const ResumePreview2: React.FC<ResumePreviewProps> = ({
                   </h2>
                   <Separator className="my-1 h-[1px] bg-gray-300" />
                   <div className="space-y-1 mt-2">
-                    <p className="text-xs text-gray-700 break-words">
-                      {person.email}
+                    <p className="text-xs text-gray-700">
+                      <ResumeLink value={person.email} />
                     </p>
-                    <p className="text-xs text-gray-700 break-words">
+                    <p className="text-xs text-gray-700">
                       {person.phoneNumber}
                     </p>
-                    <p className="text-xs text-gray-700 break-words">
-                      {person.linkedin}
+                    {(person.city || person.country) && (
+                      <p className="text-xs text-gray-700">
+                        {[person.city, person.country].filter(Boolean).join(', ')}
+                      </p>
+                    )}
+                    <p className="text-xs text-gray-700">
+                      <ResumeLink value={person.linkedin} label="LinkedIn" />
                     </p>
-                    <p className="text-xs text-gray-700 break-words">
-                      {person.github}
+                    <p className="text-xs text-gray-700">
+                      <ResumeLink value={person.github} label="GitHub" />
                     </p>
                   </div>
                 </div>
               </div>
             ))}
           {sectionVisibility.skills && skillData.length > 0 && (
-            <div className="mt-4">
+            <div className="mt-6">
               <h2
                 className="text-base font-semibold text-gray-900 mb-1"
                 style={{ color: headingColor }}
@@ -164,9 +204,9 @@ export const ResumePreview2: React.FC<ResumePreviewProps> = ({
                 Skills
               </h2>
               <Separator className="my-1 h-[1px] bg-gray-300" />
-              <div className="mt-2">
+              <div className="mt-2 grid grid-cols-1 gap-y-1">
                 {skillData.map((skill, index) => (
-                  <div key={index} className="text-xs text-gray-700 mb-1">
+                  <div key={index} className="text-xs text-gray-700">
                     • {skill.skillName}
                   </div>
                 ))}
@@ -193,7 +233,7 @@ export const ResumePreview2: React.FC<ResumePreviewProps> = ({
 
           {sectionVisibility.workExperience &&
             workExperienceData.length > 0 && (
-              <div className="mb-5">
+              <div className="mb-4">
                 <h2
                   className="text-base font-semibold text-gray-900 mb-1"
                   style={{ color: headingColor }}
@@ -223,7 +263,7 @@ export const ResumePreview2: React.FC<ResumePreviewProps> = ({
             )}
 
           {sectionVisibility.projects && projectData.length > 0 && (
-            <div className="mb-5">
+            <div className="mb-4">
               <h2
                 className="text-base font-semibold text-gray-900 mb-1"
                 style={{ color: headingColor }}
@@ -245,7 +285,7 @@ export const ResumePreview2: React.FC<ResumePreviewProps> = ({
           )}
 
           {sectionVisibility.education && educationData.length > 0 && (
-            <div className="mb-5">
+            <div className="mb-4">
               <h2
                 className="text-base font-semibold text-gray-900 mb-1"
                 style={{ color: headingColor }}
@@ -270,7 +310,7 @@ export const ResumePreview2: React.FC<ResumePreviewProps> = ({
           )}
 
           {sectionVisibility.achievements && achievementData.length > 0 && (
-            <div className="mb-5">
+            <div className="mb-4">
               <h2
                 className="text-base font-semibold text-gray-900 mb-1"
                 style={{ color: headingColor }}

--- a/src/components/resumeEditor/ResumePreview2.tsx
+++ b/src/components/resumeEditor/ResumePreview2.tsx
@@ -182,7 +182,9 @@ export const ResumePreview2: React.FC<ResumePreviewProps> = ({
                     </p>
                     {(person.city || person.country) && (
                       <p className="text-xs text-gray-700">
-                        {[person.city, person.country].filter(Boolean).join(', ')}
+                        {[person.city, person.country]
+                          .filter(Boolean)
+                          .join(', ')}
                       </p>
                     )}
                     <p className="text-xs text-gray-700">

--- a/src/components/resumeEditor/editor.tsx
+++ b/src/components/resumeEditor/editor.tsx
@@ -529,6 +529,9 @@ export default function ResumeEditor({
     setIsGeneratingPDF(true);
     optimizePdfContent();
     try {
+      if ((document as any).fonts?.ready) {
+        await (document as any).fonts.ready;
+      }
       const element = resumeRef.current.querySelector(
         '.resumeContent',
       ) as HTMLElement;
@@ -592,6 +595,23 @@ export default function ResumeEditor({
         undefined,
         'FAST',
       );
+
+      // Overlay real clickable links — scale DOM px → PDF mm
+      // canvas.width = element.offsetWidth * scale(3), ratio = pdfWidth/canvas.width
+      // so: elementPx * scale * ratio = mm  →  elementPx * (canvas.width/element.offsetWidth) * ratio
+      const domToMm = (canvas.width / element.offsetWidth) * ratio;
+      const elemRect = element.getBoundingClientRect();
+      element.querySelectorAll('a[href]').forEach((anchor) => {
+        const href = anchor.getAttribute('href');
+        // skip empty, fragment, and phone links
+        if (!href || href === '#' || href.startsWith('tel:')) return;
+        const rect = anchor.getBoundingClientRect();
+        const x = xOffset + (rect.left - elemRect.left) * domToMm;
+        const y = yOffset + (rect.top - elemRect.top) * domToMm;
+        const w = rect.width * domToMm;
+        const h = rect.height * domToMm;
+        pdf.link(x, y, w, h, { url: href });
+      });
 
       if (imgPdfHeight > pdfHeight) {
         let heightLeft = imgPdfHeight;

--- a/src/components/shared/chat.tsx
+++ b/src/components/shared/chat.tsx
@@ -62,7 +62,6 @@ import {
   updateConversationWithMessageTransaction,
   updateDataInFirestore,
 } from '@/utils/common/firestoreUtils';
-import { axiosInstance } from '@/lib/axiosinstance';
 import { RootState } from '@/lib/store';
 import { useToast } from '@/components/ui/use-toast';
 import { uploadFileViaSignedUrl } from '@/services/imageSignedUpload';

--- a/src/components/ui/meetingDialog.tsx
+++ b/src/components/ui/meetingDialog.tsx
@@ -14,12 +14,11 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { DateTimePicker } from '@/components/ui/date-picker';
-import { ScrollArea } from '@/components/ui/scroll-area';
 import { useEffect, useState } from 'react';
 import dayjs from 'dayjs';
 import { Plus, CalendarIcon, Users, X } from 'lucide-react';
 import { axiosInstance } from '@/lib/axiosinstance';
-import { toast } from '@/hooks/use-toast';
+import { toast } from '@/components/ui/use-toast';
 
 interface MeetingDialogProps {
   isOpen: boolean;
@@ -37,34 +36,43 @@ export function MeetingDialog({ isOpen, onClose }: MeetingDialogProps) {
   const [endTime, setEndTime] = useState<string>('10:00');
   const [attendees, setAttendees] = useState<string[]>(['']);
   const [submitting, setSubmitting] = useState(false);
-  const [meetLink, setMeetLink] = useState<string>('');
   const [timeError, setTimeError] = useState<string>('');
 
-  const DRAFT_KEY = 'DEHIX_MEETING_DRAFT';
-
   const handleCreateMeet = async (meetingData: object) => {
-    const response = await axiosInstance.post(`/meeting/admin`, meetingData);
-    console.log('RESPONSE', response);
+    const response = await axiosInstance.post(`/meeting`, meetingData);
+
+    const inviteStatus = response?.data?.inviteStatus;
+    if (inviteStatus && inviteStatus !== 'success') {
+      toast({
+        variant: 'destructive',
+        title: 'Meeting creation failed',
+        description:
+          response?.data?.message ||
+          'Failed to create meeting. Please try again.',
+      });
+      return;
+    }
+
     const link =
       response?.data?.data?.hangoutLink ||
       response?.data?.data?.htmlLink ||
       response?.data?.hangoutLink ||
+      response?.data?.meetLink ||
       response?.data?.link ||
       '';
 
-    if (link) {
-      setMeetLink(String(link));
+    if (link && link !== 'No calendar event created') {
       toast({
         title: 'Meeting created',
         description: 'Your meeting link is ready.',
       });
     } else {
       toast({
-        variant: 'destructive',
-        title: 'Meeting created, but no link returned',
-        description: 'Please check your calendar for the event link.',
+        title: 'Meeting scheduled',
+        description: 'Meeting created. Check your calendar for the link.',
       });
     }
+    onClose();
   };
 
   const validateTime = () => {
@@ -146,7 +154,7 @@ export function MeetingDialog({ isOpen, onClose }: MeetingDialogProps) {
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="sm:max-w-[600px] max-h-[90vh]">
+      <DialogContent className="sm:max-w-[600px] max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Users className="h-5 w-5" />
@@ -157,171 +165,134 @@ export function MeetingDialog({ isOpen, onClose }: MeetingDialogProps) {
           </DialogDescription>
         </DialogHeader>
 
-        <ScrollArea className="max-h-[calc(90vh-120px)] pr-4">
-          <form onSubmit={handleSubmit} className="space-y-6 py-4">
-            {/* Basic Information */}
-            <Card>
-              <CardHeader className="pb-3">
-                <CardTitle className="text-base">Basic Information</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <div className="space-y-2">
-                  <Label htmlFor="summary">Meeting Title *</Label>
+        <form onSubmit={handleSubmit} className="space-y-6 py-4">
+          {/* Basic Information */}
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base">Basic Information</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="summary">Meeting Title *</Label>
+                <Input
+                  id="summary"
+                  value={summary}
+                  onChange={(e) => setSummary(e.target.value)}
+                  placeholder="Enter meeting title"
+                  required
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="description">Description</Label>
+                <Textarea
+                  id="description"
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  placeholder="Provide a detailed description of the meeting"
+                  className="min-h-[80px] resize-none"
+                  rows={3}
+                />
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Date and Time */}
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base flex items-center gap-2">
+                <CalendarIcon className="h-4 w-4" />
+                Date and Time
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-1 gap-4">
+                <DateTimePicker
+                  date={startDate}
+                  onDateChange={(date) => date && setStartDate(date)}
+                  time={startTime}
+                  onTimeChange={setStartTime}
+                  label="Start Date & Time *"
+                />
+
+                <DateTimePicker
+                  date={endDate}
+                  onDateChange={(date) => date && setEndDate(date)}
+                  time={endTime}
+                  onTimeChange={setEndTime}
+                  label="End Date & Time *"
+                />
+              </div>
+
+              {timeError && (
+                <div className="text-sm text-destructive bg-destructive/10 p-3 rounded-md">
+                  {timeError}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Attendees */}
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base flex items-center gap-2">
+                <Users className="h-4 w-4" />
+                Attendees
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {attendees.map((attendee, index) => (
+                <div className="flex items-center gap-2" key={index}>
                   <Input
-                    id="summary"
-                    value={summary}
-                    onChange={(e) => setSummary(e.target.value)}
-                    placeholder="Enter meeting title"
-                    required
+                    value={attendee}
+                    onChange={(e) =>
+                      handleAttendeeChange(index, e.target.value)
+                    }
+                    placeholder="Enter attendee email"
+                    type="email"
+                    className="flex-grow"
+                    required={index === 0}
                   />
-                </div>
-
-                <div className="space-y-2">
-                  <Label htmlFor="description">Description</Label>
-                  <Textarea
-                    id="description"
-                    value={description}
-                    onChange={(e) => setDescription(e.target.value)}
-                    placeholder="Provide a detailed description of the meeting"
-                    className="min-h-[80px] resize-none"
-                    rows={3}
-                  />
-                </div>
-              </CardContent>
-            </Card>
-
-            {/* Date and Time */}
-            <Card>
-              <CardHeader className="pb-3">
-                <CardTitle className="text-base flex items-center gap-2">
-                  <CalendarIcon className="h-4 w-4" />
-                  Date and Time
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <div className="grid grid-cols-1 gap-4">
-                  <DateTimePicker
-                    date={startDate}
-                    onDateChange={(date) => date && setStartDate(date)}
-                    time={startTime}
-                    onTimeChange={setStartTime}
-                    label="Start Date & Time *"
-                  />
-
-                  <DateTimePicker
-                    date={endDate}
-                    onDateChange={(date) => date && setEndDate(date)}
-                    time={endTime}
-                    onTimeChange={setEndTime}
-                    label="End Date & Time *"
-                  />
-                </div>
-
-                {timeError && (
-                  <div className="text-sm text-destructive bg-destructive/10 p-3 rounded-md">
-                    {timeError}
-                  </div>
-                )}
-              </CardContent>
-            </Card>
-
-            {/* Attendees */}
-            <Card>
-              <CardHeader className="pb-3">
-                <CardTitle className="text-base flex items-center gap-2">
-                  <Users className="h-4 w-4" />
-                  Attendees
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-3">
-                {attendees.map((attendee, index) => (
-                  <div className="flex items-center gap-2" key={index}>
-                    <Input
-                      value={attendee}
-                      onChange={(e) =>
-                        handleAttendeeChange(index, e.target.value)
-                      }
-                      placeholder="Enter attendee email"
-                      type="email"
-                      className="flex-grow"
-                      required={index === 0}
-                    />
-                    {attendees.length > 1 && (
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="icon"
-                        onClick={() => removeAttendee(index)}
-                        className="flex-shrink-0"
-                      >
-                        <X className="h-4 w-4" />
-                      </Button>
-                    )}
-                    {index === attendees.length - 1 && (
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="icon"
-                        onClick={addAttendee}
-                        className="flex-shrink-0"
-                      >
-                        <Plus className="h-4 w-4" />
-                      </Button>
-                    )}
-                  </div>
-                ))}
-                <p className="text-sm text-muted-foreground">
-                  Add email addresses of meeting attendees
-                </p>
-              </CardContent>
-            </Card>
-
-            <DialogFooter className="flex justify-center pt-4">
-              <Button
-                type="submit"
-                disabled={submitting}
-                className="min-w-[140px]"
-              >
-                {submitting ? 'Creating Meeting...' : 'Create Meeting'}
-              </Button>
-            </DialogFooter>
-          </form>
-
-          {meetLink && (
-            <Card className="mt-4">
-              <CardContent className="pt-6">
-                <div className="space-y-3">
-                  <Label className="text-base font-medium">Meeting Link</Label>
-                  <div className="flex gap-2">
-                    <Input value={meetLink} readOnly className="flex-grow" />
+                  {attendees.length > 1 && (
                     <Button
                       type="button"
                       variant="outline"
-                      onClick={async () => {
-                        try {
-                          await navigator.clipboard.writeText(meetLink);
-                          toast({
-                            title: 'Copied!',
-                            description: 'Meeting link copied to clipboard.',
-                          });
-                        } catch (error) {
-                          console.error('Failed to copy:', error);
-                          toast({
-                            variant: 'destructive',
-                            title: 'Copy failed',
-                            description: 'Please copy the link manually.',
-                          });
-                        }
-                      }}
+                      size="icon"
+                      onClick={() => removeAttendee(index)}
+                      className="flex-shrink-0"
                     >
-                      Copy
+                      <X className="h-4 w-4" />
                     </Button>
-                  </div>
+                  )}
+                  {index === attendees.length - 1 && (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="icon"
+                      onClick={addAttendee}
+                      className="flex-shrink-0"
+                    >
+                      <Plus className="h-4 w-4" />
+                    </Button>
+                  )}
                 </div>
-              </CardContent>
-            </Card>
-          )}
-        </ScrollArea>
+              ))}
+              <p className="text-sm text-muted-foreground">
+                Add email addresses of meeting attendees
+              </p>
+            </CardContent>
+          </Card>
+
+          <DialogFooter className="flex justify-center pt-4">
+            <Button
+              type="submit"
+              disabled={submitting}
+              className="min-w-[140px]"
+            >
+              {submitting ? 'Creating Meeting...' : 'Create Meeting'}
+            </Button>
+          </DialogFooter>
+        </form>
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
## Summary
- Fixed PDF download not matching the UI resume layout (fonts await before canvas capture)
- Added real clickable links (email, GitHub, LinkedIn) in downloaded PDF via pdf.link()
- Added location (city, country) field to both resume templates
- Fixed date parsing to be UTC-safe (no timezone day-shift)
- Polished resume layout: consistent spacing, 2-column skills/achievements, border outline
- Removed unused axiosInstance import in chat.tsx



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * City and country fields added to resume personal data
  * Email, phone, and social media links in resumes are now clickable and labeled
  * Interactive links included in PDF exports
  * Option to toggle the resume summary section

* **Improvements**
  * Redesigned meeting scheduling interface with improved error handling and clearer messages
  * Enhanced font rendering in PDF generation
  * Refined spacing, responsive two-column layout for Skills/Achievements, and layout adjustments across resume sections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->