### PR TITLE
Fix skeleton issues in levels-badges and streak page

### DIFF
--- a/src/app/freelancer/settings/levels-badges/page.tsx
+++ b/src/app/freelancer/settings/levels-badges/page.tsx
@@ -601,11 +601,58 @@ export default function LevelsAndBadgesPage() {
         contentClassName="md:pl-[50px] flex-1 flex flex-col min-h-screen"
         containerClassName="flex min-h-screen w-full bg-background"
       >
-        <div className="max-w-7xl mx-auto">
+        <div className="max-w-7xl mx-auto space-y-8">
           <div className="space-y-4">
             <Skeleton className="h-10 w-64" />
-            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            <Skeleton className="h-6 w-96" />
+          </div>
+
+          <Card>
+            <CardHeader>
+              <Skeleton className="h-6 w-3/4" />
+              <Skeleton className="h-4 w-1/2 mt-2" />
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="h-4 w-full mt-2" />
+              <Skeleton className="h-4 w-5/6 mt-2" />
+              <Skeleton className="h-4 w-4/6 mt-2" />
+            </CardContent>
+          </Card>
+
+          <div className="space-y-4">
+            <Skeleton className="h-9 w-32" />
+            <div className="space-y-4 relative">
+              <div className="absolute left-5 top-0 bottom-0 w-0.5 bg-border" />
+
               {[...Array(3)].map((_, i) => (
+                <div key={i} className="relative pl-12">
+                  <div className="absolute left-0 top-4 flex h-10 w-10 items-center justify-center rounded-full border-4 border-background bg-muted" />
+
+                  <Card>
+                    <CardHeader className="space-y-1">
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0 flex-1">
+                          <Skeleton className="h-6 w-48" />
+                          <Skeleton className="h-4 w-32 mt-2" />
+                        </div>
+                        <Skeleton className="h-6 w-20" />
+                      </div>
+                    </CardHeader>
+                    <CardContent className="space-y-3">
+                      <Skeleton className="h-4 w-full" />
+                      <Skeleton className="h-4 w-5/6" />
+                      <Skeleton className="h-4 w-4/6" />
+                    </CardContent>
+                  </Card>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="space-y-4">
+            <Skeleton className="h-9 w-32" />
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {[...Array(6)].map((_, i) => (
                 <Card key={i}>
                   <CardHeader>
                     <Skeleton className="h-6 w-3/4" />
@@ -620,13 +667,6 @@ export default function LevelsAndBadgesPage() {
               ))}
             </div>
           </div>
-          <Skeleton className="h-9 w-32" />
-        </div>
-        <Skeleton className="h-28 w-full" />
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          <Skeleton className="h-36 w-full" />
-          <Skeleton className="h-36 w-full" />
-          <Skeleton className="h-36 w-full" />
         </div>
       </FreelancerSettingsLayout>
     );

--- a/src/app/freelancer/settings/streak/page.tsx
+++ b/src/app/freelancer/settings/streak/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState } from 'react';
 import { useQuery, useMutation } from '@tanstack/react-query';
-import { Flame, Calendar, Trophy, Gift, Check, Lock } from 'lucide-react';
+import { Flame, Trophy, Gift, Check, Lock } from 'lucide-react';
 
 import { updateConnectsBalance } from '@/lib/updateConnects';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -329,32 +329,111 @@ export default function StreakPage() {
           <div className="flex items-center justify-between space-y-2">
             <div>
               <h1 className="text-3xl font-bold tracking-tight">
-                Login Streak
+                <Skeleton className="h-9 w-48" />
               </h1>
               <p className="text-muted-foreground">
-                Build your streak by logging in daily and earn connect rewards.
+                <Skeleton className="h-5 w-80 mt-2" />
               </p>
             </div>
           </div>
 
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            <Skeleton className="h-[104px]" />
-            <Skeleton className="h-[104px]" />
-            <Skeleton className="h-[104px]" />
-          </div>
+          <section className="space-y-3">
+            <div className="flex items-center justify-between gap-3">
+              <h2 className="text-base font-semibold tracking-tight">
+                <Skeleton className="h-6 w-24" />
+              </h2>
+            </div>
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              <Skeleton className="h-[104px]" />
+              <Skeleton className="h-[104px]" />
+              <Skeleton className="h-[104px]" />
+            </div>
+          </section>
 
-          <Card>
-            <CardHeader>
-              <Skeleton className="h-6 w-40" />
-            </CardHeader>
-            <CardContent>
-              <div className="grid gap-4 md:grid-cols-3">
-                <Skeleton className="h-28" />
-                <Skeleton className="h-28" />
-                <Skeleton className="h-28" />
-              </div>
-            </CardContent>
-          </Card>
+          <section className="space-y-3">
+            <div className="flex items-center justify-between gap-3">
+              <h2 className="text-base font-semibold tracking-tight">
+                <Skeleton className="h-6 w-32" />
+              </h2>
+            </div>
+            <Card className="overflow-hidden">
+              <CardHeader>
+                <Skeleton className="h-6 w-40" />
+              </CardHeader>
+              <CardContent>
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="min-w-0">
+                      <Skeleton className="h-5 w-20" />
+                      <Skeleton className="h-6 w-32 mt-1" />
+                    </div>
+                    <Skeleton className="h-6 w-20" />
+                  </div>
+                  <Skeleton className="h-2 w-full" />
+                  <Skeleton className="h-4 w-24 mt-1" />
+                </div>
+              </CardContent>
+            </Card>
+          </section>
+
+          <section className="space-y-3">
+            <div className="flex items-center justify-between gap-3">
+              <h2 className="text-base font-semibold tracking-tight">
+                <Skeleton className="h-6 w-20" />
+              </h2>
+            </div>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+              {[...Array(8)].map((_, i) => (
+                <Card key={i} className="relative overflow-hidden">
+                  <CardHeader className="space-y-2">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <CardTitle className="text-base truncate flex items-center gap-2">
+                          <Skeleton className="h-8 w-8 rounded" />
+                          <Skeleton className="h-6 w-32" />
+                        </CardTitle>
+                        <Skeleton className="h-4 w-16 mt-1" />
+                      </div>
+                      <Skeleton className="h-6 w-16" />
+                    </div>
+                  </CardHeader>
+                  <CardContent className="space-y-4">
+                    <div className="space-y-2">
+                      <Skeleton className="h-2 w-full" />
+                      <div className="flex items-center justify-between text-xs">
+                        <Skeleton className="h-3 w-20" />
+                        <Skeleton className="h-3 w-8" />
+                      </div>
+                    </div>
+                    <Skeleton className="h-9 w-full" />
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          </section>
+
+          <section className="space-y-3">
+            <div className="flex items-center justify-between gap-3">
+              <h2 className="text-base font-semibold tracking-tight">
+                <Skeleton className="h-6 w-16" />
+              </h2>
+            </div>
+            <Card>
+              <CardHeader>
+                <Skeleton className="h-6 w-32" />
+              </CardHeader>
+              <CardContent className="space-y-3 text-sm text-muted-foreground">
+                <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+                  {[...Array(4)].map((_, i) => (
+                    <div key={i} className="rounded-lg border bg-muted/30 p-4">
+                      <Skeleton className="h-5 w-24 mb-2" />
+                      <Skeleton className="h-4 w-full" />
+                    </div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          </section>
         </div>
       </FreelancerSettingsLayout>
     );


### PR DESCRIPTION
Fixed UI skeleton rendering issues on Levels, Badges, and Streak pages.
<img width="1365" height="678" alt="Screenshot 2026-03-01 214015" src="https://github.com/user-attachments/assets/14cd93f0-9ec8-4167-94a2-7dc79bb3a97e" />
<img width="1365" height="685" alt="Screenshot 2026-03-01 214308" src="https://github.com/user-attachments/assets/7f7006ef-e1ee-42ac-afcf-a5f47081a8a8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Improved loading experience on Levels and Badges page with enhanced skeleton placeholders to better represent the final content layout
  * Enhanced loading states on Streak page with comprehensive placeholder structures, including expanded sections and grid layouts that reflect the complete page design

<!-- end of auto-generated comment: release notes by coderabbit.ai -->