### PR TITLE
Fix: single entry sections in resume editor

### DIFF
--- a/src/components/form/resumeform/PersonalInfo.tsx
+++ b/src/components/form/resumeform/PersonalInfo.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { User, X, Mail, Phone, MapPin, Github, Linkedin } from 'lucide-react';
 
-import { AddButton } from '@/components/ui/AddButton';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import {
@@ -47,22 +46,6 @@ export const PersonalInfo: React.FC<PersonalInfoProps> = ({
       [field]: value,
     };
     setPersonalData(updatedPersonalData);
-  };
-
-  const handleAddPersonalInfo = () => {
-    setPersonalData([
-      ...personalData,
-      {
-        firstName: '',
-        lastName: '',
-        city: '',
-        country: '',
-        phoneNumber: '',
-        email: '',
-        github: '',
-        linkedin: '',
-      },
-    ]);
   };
 
   const handleRemovePersonalInfo = (index: number) => {
@@ -249,7 +232,6 @@ export const PersonalInfo: React.FC<PersonalInfoProps> = ({
           </Card>
         ))}
       </form>
-      <AddButton onClick={handleAddPersonalInfo} />
     </div>
   );
 };

--- a/src/components/form/resumeform/SummaryInfo.tsx
+++ b/src/components/form/resumeform/SummaryInfo.tsx
@@ -2,7 +2,6 @@ import React, { useEffect } from 'react';
 // import { useForm } from 'react-hook-form';
 import { NotebookText, X } from 'lucide-react';
 
-import { AddButton } from '@/components/ui/AddButton';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import {
@@ -50,10 +49,6 @@ export const SummaryInfo: React.FC<SummaryInfoProps> = ({
   };
 
   useEffect(() => {}, [workExperienceData]); // Logs data every time it updates
-
-  const handleAddSummary = () => {
-    setSummaryData([...summaryData, '']);
-  };
 
   const handleRemoveSummary = (index: number) => {
     const updatedSummaryData = summaryData.filter((_, i) => i !== index);
@@ -152,8 +147,6 @@ export const SummaryInfo: React.FC<SummaryInfoProps> = ({
           </Card>
         ))}
       </form>
-
-      <AddButton onClick={handleAddSummary} />
 
       {/* <div className="flex justify-center mt-4">
         <Button className="text-center bg-green-500 hover:bg-green-600 text-white">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the ability to add new personal information entries via the UI; existing entries can still be edited and removed.
  * Removed the ability to add new summary entries via the UI; existing entries remain editable and removable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->