### PR TITLE
Added Refresh Button & Fixed API Repeated Calls

### DIFF
--- a/src/app/business/settings/kyc/page.tsx
+++ b/src/app/business/settings/kyc/page.tsx
@@ -1,10 +1,25 @@
 'use client';
 import { useSelector } from 'react-redux';
+import dynamic from 'next/dynamic';
 
 import { RootState } from '@/lib/store';
-import { KYCForm } from '@/components/form/kycBusinessForm';
 import BusinessSettingsLayout from '@/components/layout/BusinessSettingsLayout';
 import { useKycTour } from '@/components/tour/business-profile/useKycTour';
+
+const KYCForm = dynamic(
+  () =>
+    import('@/components/form/kycBusinessForm').then((mod) => ({
+      default: mod.KYCForm,
+    })),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="flex items-center justify-center p-8">
+        Loading KYC Form...
+      </div>
+    ),
+  },
+);
 
 export default function PersonalInfo() {
   const user = useSelector((state: RootState) => state.user);

--- a/src/app/business/settings/kyc/page.tsx
+++ b/src/app/business/settings/kyc/page.tsx
@@ -6,7 +6,7 @@ import dynamic from 'next/dynamic';
 import { RootState } from '@/lib/store';
 import BusinessSettingsLayout from '@/components/layout/BusinessSettingsLayout';
 import { Skeleton } from '@/components/ui/skeleton';
-import { Card, CardContent } from '@/components/ui/card';
+import { Card } from '@/components/ui/card';
 import { useKycTour } from '@/components/tour/business-profile/useKycTour';
 
 const KYCForm = dynamic(
@@ -25,7 +25,7 @@ const KYCForm = dynamic(
           </div>
           <Skeleton className="h-6 w-20 rounded-full" />
         </div>
-        
+
         {/* KycStatusAlert skeleton */}
         <Skeleton className="h-16 w-full rounded-md mb-6" />
 

--- a/src/app/business/settings/kyc/page.tsx
+++ b/src/app/business/settings/kyc/page.tsx
@@ -1,9 +1,12 @@
 'use client';
+import React, { Fragment } from 'react';
 import { useSelector } from 'react-redux';
 import dynamic from 'next/dynamic';
 
 import { RootState } from '@/lib/store';
 import BusinessSettingsLayout from '@/components/layout/BusinessSettingsLayout';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Card, CardContent } from '@/components/ui/card';
 import { useKycTour } from '@/components/tour/business-profile/useKycTour';
 
 const KYCForm = dynamic(
@@ -14,9 +17,79 @@ const KYCForm = dynamic(
   {
     ssr: false,
     loading: () => (
-      <div className="flex items-center justify-center p-8">
-        Loading KYC Form...
-      </div>
+      <Card className="p-6 md:p-8 shadow-lg relative rounded-xl w-full max-w-6xl mx-auto">
+        <div className="flex justify-between items-center mb-4 md:mb-6">
+          <div>
+            <Skeleton className="h-8 md:h-10 w-64 md:w-80 mb-2" />
+            <Skeleton className="h-4 w-48" />
+          </div>
+          <Skeleton className="h-6 w-20 rounded-full" />
+        </div>
+        
+        {/* KycStatusAlert skeleton */}
+        <Skeleton className="h-16 w-full rounded-md mb-6" />
+
+        <div className="grid grid-cols-1 md:grid-cols-12 gap-6">
+          {/* Mobile Horizontal Stepper Skeleton */}
+          <div className="md:hidden col-span-full -mt-1 flex items-center justify-between px-2">
+            {[1, 2, 3].map((i) => (
+              <Fragment key={i}>
+                <Skeleton className="h-6 w-6 rounded-full shrink-0" />
+                {i < 3 && <Skeleton className="h-px w-full mx-2" />}
+              </Fragment>
+            ))}
+          </div>
+
+          {/* Sidebar Stepper Skeleton */}
+          <aside className="hidden md:block md:col-span-4 lg:col-span-3">
+            <div className="space-y-6 pe-6 border-r border-muted/20">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="flex gap-4">
+                  <div className="space-y-2 w-full">
+                    <Skeleton className="h-5 w-3/4" />
+                    <Skeleton className="h-3 w-full" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </aside>
+
+          {/* Main Content Skeleton (Step 1) */}
+          <section className="md:col-span-8 lg:col-span-9 space-y-6">
+            <div>
+              <Skeleton className="h-3 w-16 mb-2" />
+              <Skeleton className="h-7 w-48 mb-2" />
+              <Skeleton className="h-4 w-64" />
+            </div>
+
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-10 w-full rounded-md" />
+            </div>
+
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-10 w-full rounded-md" />
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              <div className="space-y-2">
+                <Skeleton className="h-4 w-40" />
+                <Skeleton className="h-[160px] w-full rounded-xl" />
+              </div>
+              <div className="space-y-2">
+                <Skeleton className="h-4 w-40" />
+                <Skeleton className="h-[160px] w-full rounded-xl" />
+              </div>
+            </div>
+
+            <div className="flex flex-col sm:flex-row gap-3 pt-2">
+              <Skeleton className="h-10 w-full sm:w-24 rounded-md" />
+              <Skeleton className="h-10 flex-1 rounded-md" />
+            </div>
+          </section>
+        </div>
+      </Card>
     ),
   },
 );

--- a/src/app/freelancer/settings/kyc/page.tsx
+++ b/src/app/freelancer/settings/kyc/page.tsx
@@ -1,10 +1,19 @@
 'use client';
 import { useSelector } from 'react-redux';
+import dynamic from 'next/dynamic';
 
 import FreelancerSettingsLayout from '../../../../components/layout/FreelancerSettingsLayout';
 
 import { RootState } from '@/lib/store';
-import KYCForm from '@/components/form/kycFreelancerForm';
+
+const KYCForm = dynamic(() => import('@/components/form/kycFreelancerForm'), {
+  ssr: false,
+  loading: () => (
+    <div className="flex items-center justify-center p-8">
+      Loading KYC Form...
+    </div>
+  ),
+});
 
 export default function PersonalInfo() {
   const user = useSelector((state: RootState) => state.user);

--- a/src/app/freelancer/settings/kyc/page.tsx
+++ b/src/app/freelancer/settings/kyc/page.tsx
@@ -6,12 +6,86 @@ import FreelancerSettingsLayout from '../../../../components/layout/FreelancerSe
 
 import { RootState } from '@/lib/store';
 
+import React, { Fragment } from 'react';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Card } from '@/components/ui/card';
+
 const KYCForm = dynamic(() => import('@/components/form/kycFreelancerForm'), {
   ssr: false,
   loading: () => (
-    <div className="flex items-center justify-center p-8">
-      Loading KYC Form...
-    </div>
+    <Card className="p-6 md:p-8 shadow-lg relative rounded-xl w-full max-w-6xl mx-auto">
+      <div className="flex justify-between items-center mb-4 md:mb-6">
+        <div>
+          <Skeleton className="h-8 md:h-10 w-64 md:w-80 mb-2" />
+          <Skeleton className="h-4 w-48" />
+        </div>
+        <Skeleton className="h-6 w-20 rounded-full" />
+      </div>
+      
+      {/* KycStatusAlert skeleton */}
+      <Skeleton className="h-16 w-full rounded-md mb-6" />
+
+      <div className="grid grid-cols-1 md:grid-cols-12 gap-6">
+        {/* Mobile Horizontal Stepper Skeleton */}
+        <div className="md:hidden col-span-full -mt-1 flex items-center justify-between px-2">
+          {[1, 2, 3].map((i) => (
+            <Fragment key={i}>
+              <Skeleton className="h-6 w-6 rounded-full shrink-0" />
+              {i < 3 && <Skeleton className="h-px w-full mx-2" />}
+            </Fragment>
+          ))}
+        </div>
+
+        {/* Sidebar Stepper Skeleton */}
+        <aside className="hidden md:block md:col-span-4 lg:col-span-3">
+          <div className="space-y-6 pe-6 border-r border-muted/20">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="flex gap-4">
+                <div className="space-y-2 w-full">
+                  <Skeleton className="h-5 w-3/4" />
+                  <Skeleton className="h-3 w-full" />
+                </div>
+              </div>
+            ))}
+          </div>
+        </aside>
+
+        {/* Main Content Skeleton (Step 1) */}
+        <section className="md:col-span-8 lg:col-span-9 space-y-6">
+          <div>
+            <Skeleton className="h-3 w-16 mb-2" />
+            <Skeleton className="h-7 w-48 mb-2" />
+            <Skeleton className="h-4 w-64" />
+          </div>
+
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-10 w-full rounded-md" />
+          </div>
+
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-10 w-full rounded-md" />
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-40" />
+              <Skeleton className="h-[160px] w-full rounded-xl" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-40" />
+              <Skeleton className="h-[160px] w-full rounded-xl" />
+            </div>
+          </div>
+
+          <div className="flex flex-col sm:flex-row gap-3 pt-2">
+            <Skeleton className="h-10 w-full sm:w-24 rounded-md" />
+            <Skeleton className="h-10 flex-1 rounded-md" />
+          </div>
+        </section>
+      </div>
+    </Card>
   ),
 });
 

--- a/src/app/freelancer/settings/kyc/page.tsx
+++ b/src/app/freelancer/settings/kyc/page.tsx
@@ -1,12 +1,11 @@
 'use client';
 import { useSelector } from 'react-redux';
 import dynamic from 'next/dynamic';
+import React, { Fragment } from 'react';
 
 import FreelancerSettingsLayout from '../../../../components/layout/FreelancerSettingsLayout';
 
 import { RootState } from '@/lib/store';
-
-import React, { Fragment } from 'react';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Card } from '@/components/ui/card';
 
@@ -21,7 +20,7 @@ const KYCForm = dynamic(() => import('@/components/form/kycFreelancerForm'), {
         </div>
         <Skeleton className="h-6 w-20 rounded-full" />
       </div>
-      
+
       {/* KycStatusAlert skeleton */}
       <Skeleton className="h-16 w-full rounded-md mb-6" />
 

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { Wallet } from 'lucide-react';
+import { Wallet, RefreshCw } from 'lucide-react';
 import { usePathname } from 'next/navigation';
 
 import CollapsibleSidebarMenu from '../menu/collapsibleSidebarMenu';
@@ -19,6 +19,7 @@ import TourMenu from '@/components/tour/shared/TourMenu';
 import { RootState } from '@/lib/store';
 import type { TourTarget } from '@/lib/tourSlice';
 import { fetchAndUpdateConnects } from '@/lib/updateConnects';
+import { notifySuccess, notifyError } from '@/utils/toastMessage';
 
 interface HeaderProps {
   menuItemsTop: MenuItem[];
@@ -49,6 +50,7 @@ const Header: React.FC<HeaderProps> = ({
   const user = useSelector((state: RootState) => state.user);
   const dispatch = useDispatch();
   const [connects, setConnects] = useState<number>(0);
+  const [isRefreshing, setIsRefreshing] = useState(false);
   const pathname = usePathname();
 
   const userType =
@@ -71,12 +73,21 @@ const Header: React.FC<HeaderProps> = ({
 
   const refreshConnectsFromServer = useCallback(async () => {
     if (!user?.uid || !userType) return;
+    setIsRefreshing(true);
     try {
-      const balance = await fetchAndUpdateConnects(userType);
-      if (balance != null) setConnects(balance);
-      else fetchConnects();
-    } catch {
+      const balance = await fetchAndUpdateConnects(userType, true);
+      if (balance != null) {
+        setConnects(balance);
+        notifySuccess('Connects refreshed successfully!', 'Success');
+      } else {
+        fetchConnects();
+        notifySuccess('Connects data updated from cache', 'Updated');
+      }
+    } catch (error) {
       fetchConnects();
+      notifyError('Failed to refresh connects. Please try again.', 'Error');
+    } finally {
+      setIsRefreshing(false);
     }
   }, [user?.uid, userType]);
 
@@ -144,15 +155,10 @@ const Header: React.FC<HeaderProps> = ({
     fetchConnects();
     refreshRef.current();
     const updateConnects = () => fetchConnects();
-    const onVisibilityChange = () => {
-      if (document.visibilityState === 'visible') refreshRef.current();
-    };
     window.addEventListener('connectsUpdated', updateConnects);
-    document.addEventListener('visibilitychange', onVisibilityChange);
 
     return () => {
       window.removeEventListener('connectsUpdated', updateConnects);
-      document.removeEventListener('visibilitychange', onVisibilityChange);
     };
   }, [user?.uid, userType]);
 
@@ -258,12 +264,24 @@ const Header: React.FC<HeaderProps> = ({
         </div>
 
         {user?.uid ? (
-          <div data-tour="header-connects">
+          <div data-tour="header-connects" className="flex items-center gap-2">
             <DisplayConnectsDialog
               userId={user.uid}
               connects={connects}
               userType={userType}
             />
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={refreshConnectsFromServer}
+              disabled={isRefreshing}
+              className="h-9 w-9 p-0"
+              aria-label="Refresh connects"
+            >
+              <RefreshCw
+                className={`h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`}
+              />
+            </Button>
           </div>
         ) : (
           <div data-tour="header-connects">

--- a/src/components/shared/DisplayConnectsDialog.tsx
+++ b/src/components/shared/DisplayConnectsDialog.tsx
@@ -69,16 +69,13 @@ export const DisplayConnectsDialog = React.forwardRef<
 
       const newData = (response.data.data || []) as TokenRequest[];
 
-      // Get the set of processed request IDs from localStorage
       const processedRequests = new Set(
         JSON.parse(localStorage.getItem('PROCESSED_REQUESTS') || '[]'),
       );
 
       const newApprovedRequests: TokenRequest[] = [];
 
-      // Process new data - identify approved requests that haven't been processed yet
       newData.forEach((newItem: TokenRequest) => {
-        // Only process approved requests that haven't been processed yet
         if (
           newItem.status === 'APPROVED' &&
           !processedRequests.has(newItem._id)
@@ -87,7 +84,6 @@ export const DisplayConnectsDialog = React.forwardRef<
         }
       });
 
-      // Update processed requests in localStorage if there are new ones
       setData(newData);
       setFilteredData(newData);
 
@@ -95,7 +91,7 @@ export const DisplayConnectsDialog = React.forwardRef<
         try {
           let success = false;
           if (userType) {
-            const balance = await fetchAndUpdateConnects(userType);
+            const balance = await fetchAndUpdateConnects(userType, true);
             success = balance !== null;
           } else {
             const totalNewConnects = newApprovedRequests.reduce(
@@ -103,7 +99,6 @@ export const DisplayConnectsDialog = React.forwardRef<
               0,
             );
 
-            // CAS retry logic for local storage update
             let retries = 3;
             let updated = false;
 
@@ -112,8 +107,6 @@ export const DisplayConnectsDialog = React.forwardRef<
               const currentConnects = parseInt(currentStr, 10);
               const newTotal = currentConnects + totalNewConnects;
 
-              // Optimistic update attempt
-              // Check if value changed during computation (simple collision check)
               if (
                 localStorage.getItem('DHX_CONNECTS') ===
                 (currentStr === '0' && !localStorage.getItem('DHX_CONNECTS')
@@ -124,26 +117,19 @@ export const DisplayConnectsDialog = React.forwardRef<
                 updated = true;
               } else {
                 retries--;
-                await new Promise((r) => setTimeout(r, 50)); // backoff
+                await new Promise((r) => setTimeout(r, 50));
               }
 
-              // Fallback if strict CAS is not possible with just localStorage:
-              // Just verify we are writing fresh data.
-              // Since we don't have atomic hardware CAS for localStorage,
-              // we just minimize the window. The above check is best-effort.
               if (!updated && retries === 0) {
-                // Final attempt force write
                 updateConnectsBalance(currentConnects + totalNewConnects);
                 updated = true;
               }
             }
 
-            // Wait for event dispatch propagation if needed, though updateConnectsBalance is sync-like for localStorage
             await new Promise((resolve) => setTimeout(resolve, 0));
             success = true;
           }
 
-          // Only update PROCESSED_REQUESTS after fetch succeeds
           if (success) {
             const updatedProcessedRequests = new Set(processedRequests);
             newApprovedRequests.forEach((req) => {
@@ -302,6 +288,25 @@ export const DisplayConnectsDialog = React.forwardRef<
                 </p>
               </div>
               <div className="flex items-center gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="text-xs h-8"
+                  onClick={fetchConnectsRequest}
+                  disabled={loading}
+                >
+                  {loading ? (
+                    <>
+                      <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+                      Refreshing
+                    </>
+                  ) : (
+                    <>
+                      <Zap className="mr-1 h-3 w-3" />
+                      Refresh
+                    </>
+                  )}
+                </Button>
                 <RequestConnectsDialog userId={userId} />
               </div>
             </div>

--- a/src/components/shared/notification.tsx
+++ b/src/components/shared/notification.tsx
@@ -129,7 +129,7 @@ export const NotificationButton = () => {
       // Only call fetchAndUpdateConnects once for new connects-approved notifications
       if (needsRefresh && newConnectsApprovedIds.length > 0) {
         // IDs are already tracked in processedNotificationIds by the loop above
-        fetchAndUpdateConnects(userType).catch(() => {});
+        fetchAndUpdateConnects(userType, true).catch(() => {});
       }
     },
     [user?.uid, userType],

--- a/src/lib/updateConnects.ts
+++ b/src/lib/updateConnects.ts
@@ -1,17 +1,12 @@
 import { axiosInstance } from './axiosinstance';
 
-// Module-level throttle and deduplication state
 let lastFetchTime = 0;
 const MIN_INTERVAL = 5000;
 let pendingFetch: Promise<number | null> | null = null;
+let hasCalledMeApi = false;
 
-/**
- * Updates the connects balance in localStorage and dispatches event
- * to notify other components of the change.
- */
 export const updateConnectsBalance = (newBalance: number): void => {
   try {
-    // Ensure the balance is a valid number
     const num = Number(newBalance);
     const validBalance = Number.isFinite(num) ? Math.max(0, num) : 0;
     const prevRaw = localStorage.getItem('DHX_CONNECTS');
@@ -21,10 +16,8 @@ export const updateConnectsBalance = (newBalance: number): void => {
       : 0;
     const hasChanged = validBalance !== prevValidBalance;
 
-    // Update localStorage
     localStorage.setItem('DHX_CONNECTS', validBalance.toString());
 
-    // Dispatch event only when the balance value actually changes.
     if (hasChanged) {
       window.dispatchEvent(new Event('connectsUpdated'));
     }
@@ -33,29 +26,31 @@ export const updateConnectsBalance = (newBalance: number): void => {
   }
 };
 
-/**
- * Fetches the latest connects balance from the server and updates it locally.
- * Returns the new balance so callers can update UI immediately.
- */
+export const resetMeApiCallFlag = (): void => {
+  hasCalledMeApi = false;
+};
+
 export const fetchAndUpdateConnects = async (
   userType?: 'freelancer' | 'business',
+  force: boolean = false,
 ): Promise<number | null> => {
-  // Guard: if userType is unresolved, return early to prevent double-call fallback
   if (userType === undefined) {
     return null;
   }
 
-  // Throttle: if called within MIN_INTERVAL, return cached value from localStorage
-  const now = Date.now();
-  if (now - lastFetchTime < MIN_INTERVAL) {
+  if (!force && hasCalledMeApi) {
     const cached = localStorage.getItem('DHX_CONNECTS');
     return cached != null ? Number(cached) : null;
   }
 
-  // Deduplication: if a fetch is already in-flight, return the shared promise
+  const now = Date.now();
+  if (now - lastFetchTime < MIN_INTERVAL && !force) {
+    const cached = localStorage.getItem('DHX_CONNECTS');
+    return cached != null ? Number(cached) : null;
+  }
+
   pendingFetch ??= (async () => {
     try {
-      // Mark fetch attempt timestamp to throttle subsequent calls
       lastFetchTime = Date.now();
 
       const endpoints: Array<'/freelancer/me' | '/business/me'> =
@@ -72,17 +67,16 @@ export const fetchAndUpdateConnects = async (
           const connects = raw != null ? Number(raw) : NaN;
           if (!Number.isNaN(connects) && connects >= 0) {
             updateConnectsBalance(connects);
+            hasCalledMeApi = true;
             return connects;
           }
         } catch {
-          // Per-endpoint failure: continue to next endpoint. Never throw.
+          continue;
         }
       }
 
-      // Total failure: all endpoints attempted, none succeeded.
       return null;
     } finally {
-      // Clear in-flight reference
       pendingFetch = null;
     }
   })();


### PR DESCRIPTION
Added a refresh button and resolved the issue where the "me" API was being called repeatedly on every tab change.
<img width="1365" height="674" alt="Screenshot 2026-03-06 204130" src="https://github.com/user-attachments/assets/f3c26700-2333-4c22-a0ee-8fb3ebe8b7cf" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manual refresh button for connect balances in the header and dialog, with loading state and spinner.

* **Improvements**
  * KYC forms now load lazily with a visual skeleton placeholder for faster perceived page loads.
  * Connect sync now supports forced refreshes, smarter caching/throttling, and more predictable retry behavior for balance updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->