### PR TITLE
Remove redundant "Clear Filters" option

### DIFF
--- a/src/app/project-invitations/page.tsx
+++ b/src/app/project-invitations/page.tsx
@@ -527,15 +527,7 @@ const ProjectInvitationsPage: React.FC = () => {
               <div className="flex w-full items-center justify-start gap-2 sm:w-auto">
                 <Select
                   value={sortBy}
-                  onValueChange={(value) => {
-                    if (value === 'clear-filters') {
-                      setSearch('');
-                      setStatusFilter('ALL');
-                      setSortBy('createdAt');
-                    } else {
-                      setSortBy(value as any);
-                    }
-                  }}
+                  onValueChange={(value) => setSortBy(value as any)}
                 >
                   <SelectTrigger className="h-9 w-14 px-2 sm:w-auto sm:px-3">
                     <div className="flex w-full items-center justify-center gap-2 min-w-0 sm:justify-start">
@@ -580,20 +572,6 @@ const ProjectInvitationsPage: React.FC = () => {
                         </span>
                       </div>
                     </SelectItem>
-                    {(search || statusFilter !== 'ALL') && (
-                      <>
-                        <div className="h-px my-1 bg-border" />
-                        <SelectItem
-                          value="clear-filters"
-                          className="text-red-600"
-                        >
-                          <div className="flex items-center">
-                            <X className="h-4 w-4 mr-2" />
-                            <span>Clear Filters</span>
-                          </div>
-                        </SelectItem>
-                      </>
-                    )}
                   </SelectContent>
                 </Select>
 
@@ -617,6 +595,7 @@ const ProjectInvitationsPage: React.FC = () => {
                     onClick={() => {
                       setSearch('');
                       setStatusFilter('ALL');
+                      setSortBy('createdAt');
                     }}
                   >
                     Clear filters


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed redundant "Clear Filters" option from the sort-by dropdown
  * Improved the "Clear filters" button to properly reset sort order along with filters and search parameters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->