### PR TITLE
Sidebar highlight issue for application tab

### DIFF
--- a/src/app/business/talent/page.tsx
+++ b/src/app/business/talent/page.tsx
@@ -229,7 +229,10 @@ export default function Talent() {
       breadcrumbItems={[
         { label: 'Business', link: '/dashboard/business' },
         { label: 'Hire Talent', link: '#' },
-        { label: 'Overview', link: '#' },
+        {
+          label: currentTab === 'overview' ? 'Overview' : 'Applications',
+          link: '#',
+        },
       ]}
       contentClassName="flex flex-col sm:py-0 sm:pl-14"
       mainClassName="p-0"

--- a/src/components/menu/sidebarMenu.tsx
+++ b/src/components/menu/sidebarMenu.tsx
@@ -138,7 +138,27 @@ const SidebarMenu: React.FC<SidebarMenuProps> = ({
   const pathname = usePathname();
 
   const user = useSelector((state: RootState) => state.user);
-  const isActive = (href: string) => pathname === href;
+  const isActive = (href: string) => {
+    if (pathname === href) return true;
+    // Handle parent routes (e.g., /business/talent should match /business/talent/applications)
+    if (href.endsWith('/talent') && pathname.startsWith('/business/talent')) {
+      return true;
+    }
+    if (
+      href.endsWith('/projects') &&
+      pathname.startsWith('/business/projects')
+    ) {
+      return true;
+    }
+    if (
+      href.endsWith('/settings') &&
+      pathname.startsWith('/business/settings')
+    ) {
+      return true;
+    }
+    return false;
+  };
+
   const isActiveParent = (item: MenuItem) => {
     if (isActive(item.href ? item.href : '')) return true;
     return item.subItems?.some((subItem) => isActive(subItem.href));
@@ -191,6 +211,8 @@ const SidebarMenu: React.FC<SidebarMenuProps> = ({
   };
 
   const MenuIcon = ({ item }: { item: MenuItem }) => {
+    const shouldHighlight = isActive(item.href || '') || item.label === 'Dehix';
+
     if (item.subItems) {
       return (
         <Popover>
@@ -265,7 +287,7 @@ const SidebarMenu: React.FC<SidebarMenuProps> = ({
               onClick={() => setActive(item.label)}
               data-tour={item.tourId}
               className={`flex h-9 w-9 items-center justify-center rounded-lg ${
-                item.label === active || item.label === 'Dehix'
+                shouldHighlight
                   ? item.label === 'Dehix'
                     ? 'group flex h-9 w-9 shrink-0 items-center justify-center gap-2 rounded-full bg-primary text-lg font-semibold text-primary-foreground md:h-8 md:w-8 md:text-base'
                     : 'flex h-9 w-9 items-center justify-center rounded-lg bg-accent text-accent-foreground transition-colors hover:text-foreground md:h-8 md:w-8'


### PR DESCRIPTION
Fix: sidebar highlight issue when application tab is selected
<img width="1365" height="683" alt="Screenshot 2026-03-11 210550" src="https://github.com/user-attachments/assets/1eb80aa2-685d-4a72-94e4-850cc83c2e8e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Breadcrumb labels now dynamically reflect the current tab (Overview vs. Applications).
  * Sidebar menu items now properly highlight parent routes when viewing sub-pages, improving navigation clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->