### PR TITLE
fix main header sticky on the application page just like the overview page

### DIFF
--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -191,7 +191,7 @@ const Header: React.FC<HeaderProps> = ({
     <header
       role="banner"
       aria-label="Site header"
-      className="sticky top-0 z-30 flex h-14 items-center py-6 gap-4 border-b bg-muted-foreground/20 dark:bg-muted/20 px-4 sm:px-6 backdrop-blur-md"
+      className="sticky top-0 z-50 flex h-14 items-center py-6 gap-4 border-b bg-muted-foreground/20 dark:bg-muted/20 px-4 sm:px-6 backdrop-blur-md"
     >
       {/* Sidebar Menu */}
       <CollapsibleSidebarMenu

--- a/src/components/marketComponents/TalentLayout.tsx
+++ b/src/components/marketComponents/TalentLayout.tsx
@@ -95,7 +95,7 @@ const TalentLayout: React.FC<TalentLayoutProps> = ({
   };
 
   return (
-    <div className="flex min-h-screen w-full flex-col overflow-auto">
+    <div className="flex min-h-screen w-full flex-col">
       <SidebarMenu
         menuItemsTop={menuItemsTop}
         menuItemsBottom={menuItemsBottom}
@@ -116,7 +116,7 @@ const TalentLayout: React.FC<TalentLayoutProps> = ({
           ]}
         />
         {/* Filters will be added later if needed */}
-        <div className="container px-4 py-4 ">
+        <div className="container px-4 py-4">
           <Tabs
             value={activeTab}
             onValueChange={handleTabChange}
@@ -134,21 +134,22 @@ const TalentLayout: React.FC<TalentLayoutProps> = ({
             </TabsList>
           </Tabs>
         </div>
-
-        <div className="container flex-1 items-start px-4">
-          <div className="grid grid-cols-12">
-            <div className="col-span-12">
-              <TalentContent
-                activeTab={activeTab}
-                talents={activeTab === 'overview' ? [] : talents}
-                loading={loading}
-                statusFilter={statusFilter}
-                onStatusFilterChange={onStatusFilterChange}
-                talentFilter={talentFilter}
-                onTalentFilterChange={onTalentFilterChange}
-                talentOptions={talentOptions}
-                onUpdateApplicationStatus={onUpdateApplicationStatus}
-              />
+        <div className="flex-1 overflow-auto">
+          <div className="container flex-1 items-start px-4">
+            <div className="grid grid-cols-12">
+              <div className="col-span-12">
+                <TalentContent
+                  activeTab={activeTab}
+                  talents={activeTab === 'overview' ? [] : talents}
+                  loading={loading}
+                  statusFilter={statusFilter}
+                  onStatusFilterChange={onStatusFilterChange}
+                  talentFilter={talentFilter}
+                  onTalentFilterChange={onTalentFilterChange}
+                  talentOptions={talentOptions}
+                  onUpdateApplicationStatus={onUpdateApplicationStatus}
+                />
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Fixed: Main header behaves consistently across the overview and applications tabs
<img width="1365" height="684" alt="Screenshot 2026-03-13 114512" src="https://github.com/user-attachments/assets/4fb24ec8-d318-46c7-8ddc-64f1a0754f39" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced header visual layering to maintain proper element stacking order throughout the interface.
  * Optimized scrolling behavior in the talent display section with refined layout structure for improved user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->