### PR TITLE
Fix space in Chat

### DIFF
--- a/src/components/shared/ChatMessageItem.tsx
+++ b/src/components/shared/ChatMessageItem.tsx
@@ -302,7 +302,7 @@ function ChatMessageItem({
           <div
             role="button"
             tabIndex={0}
-            className="flex-shrink-0 cursor-pointer hover:opacity-80 transition-opacity"
+            className="flex-shrink-0 mr-2 cursor-pointer hover:opacity-80 transition-opacity"
             onClick={() => {
               if (onOpenProfileSidebar) {
                 onOpenProfileSidebar(message.senderId, 'user', {


### PR DESCRIPTION
Fix this -The bubble now sits perfectly next to the profile picture 
<img width="390" height="216" alt="image" src="https://github.com/user-attachments/assets/62f59871-ebe0-42b3-9157-ed3966538898" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Minor spacing adjustment applied to the profile sidebar trigger in chat messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->